### PR TITLE
Implement exact density effect calculation.

### DIFF
--- a/source/materials/include/G4DensityEffectCalc.hh
+++ b/source/materials/include/G4DensityEffectCalc.hh
@@ -62,7 +62,7 @@ struct G4DensityEffectCalcData{
   // the conduction band.  If the material is an insulator, set the
   // oscillator strength for that level to zero and the energy to
   // any value.
-  int nlev;
+  G4int nlev;
 
   // Sternheimer's "oscillator strengths", which are simply the fraction
   // of electrons in a given energy level.  For a single element, this is
@@ -70,7 +70,7 @@ struct G4DensityEffectCalcData{
   // it is weighted by the number fraction of electrons contributed by
   // each element, e.g. for water, oxygen's electrons are given 8/10 of the
   // weight.
-  double * sternf;
+  G4double * sternf;
 
   // Energy levels.  Can be found for free atoms in, e.g., T. A. Carlson.
   // Photoelectron and Auger Spectroscopy. Plenum Press, New York and London,
@@ -79,24 +79,24 @@ struct G4DensityEffectCalcData{
   // Sternheimer 1984 implies that the energy level for conduction electrons
   // (the final element of this array) should be set to zero, although the
   // computation could be run with other values.
-  double * levE;
+  G4double * levE;
 
   // The plasma energy of the material in eV, which is simply
   // 28.816 sqrt(density Z/A), with density in g/cc.
-  double plasmaE;
+  G4double plasmaE;
 
   // The mean excitation energy of the material in eV, i.e. the 'I' in the
   // Bethe energy loss formula.
-  double meanexcite;
+  G4double meanexcite;
 
 
   /***** Results of intermediate calculations *****/
 
   // The Sternheimer parameters l_i which appear in Sternheimer 1984 eq(1).
-  double * sternl;
+  G4double * sternl;
 
   // The adjusted energy levels, as found using Sternheimer 1984 eq(8).
-  double * sternEbar;
+  G4double * sternEbar;
 
 
   /***** Packaged for convenience *****/
@@ -104,7 +104,7 @@ struct G4DensityEffectCalcData{
   // The Sternheimer 'x' defined as log10(p/m) == log10(beta*gamma).
   // This is packaged with the rest of the data for convenience.
   // Any value set here is overwritten when the user calls DoFermiDeltaCalc().
-  double sternx;
+  G4double sternx;
 };
 
 /**
@@ -116,7 +116,7 @@ struct G4DensityEffectCalcData{
  * After doing this, 'par' is ready for a calculation of delta for an
  * arbitrary particle energy.  Returns true on success, false on failure.
  */
-bool SetupFermiDeltaCalc(G4DensityEffectCalcData * par);
+G4bool SetupFermiDeltaCalc(G4DensityEffectCalcData * par);
 
 /**
  * Given that SetupFermiDeltaCalc() has already been called, calculate
@@ -126,7 +126,7 @@ bool SetupFermiDeltaCalc(G4DensityEffectCalcData * par);
  *
  * Physically, delta is always non-negative.  Returns -1 on failure.
  */
-double DoFermiDeltaCalc(G4DensityEffectCalcData * par,
-                        const double sternx);
+G4double DoFermiDeltaCalc(G4DensityEffectCalcData * par,
+                        const G4double sternx);
 
 #endif

--- a/source/materials/include/G4DensityEffectCalc.hh
+++ b/source/materials/include/G4DensityEffectCalc.hh
@@ -1,0 +1,132 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+
+/*
+ * Interface to calculation of the Fermi density effect as per the method
+ * described in:
+ *
+ *   R. M. Sternheimer, M. J. Berger, and S. M. Seltzer. Density
+ *   effect for the ionization loss of charged particles in various sub-
+ *   stances. Atom. Data Nucl. Data Tabl., 30:261, 1984.
+ *
+ * Which (among other Sternheimer references) builds on:
+ *
+ *   R. M. Sternheimer. The density effect for ionization loss in
+ *   materials. Phys. Rev., 88:851­859, 1952.
+ *
+ * The returned values of delta are directly from the Sternheimer calculation,
+ * and not Sternheimer's popular three-part approximate parameterization
+ * introduced in the same paper.
+ *
+ * Author: Matthew Strait <straitm@umn.edu> 2019
+ */
+
+#ifndef G4DensityEffectCalc_HH
+#define G4DensityEffectCalc_HH
+
+/*
+ * Holds the user input and intermediate steps for calculation of
+ * the Fermi density effect parameter delta, a term in the Bethe
+ * energy loss formula.
+ */
+struct G4DensityEffectCalcData{
+  /***** User set *****/
+
+  // Number of energy levels.  If a single element, this is the number
+  // of subshells.  If several elements, this is the sum of the number
+  // of subshells.  In principle, could include levels for molecular
+  // orbitals or other non-atomic states.  The last level is always
+  // the conduction band.  If the material is an insulator, set the
+  // oscillator strength for that level to zero and the energy to
+  // any value.
+  int nlev;
+
+  // Sternheimer's "oscillator strengths", which are simply the fraction
+  // of electrons in a given energy level.  For a single element, this is
+  // the fraction of electrons in a subshell.  For a compound or mixture,
+  // it is weighted by the number fraction of electrons contributed by
+  // each element, e.g. for water, oxygen's electrons are given 8/10 of the
+  // weight.
+  double * sternf;
+
+  // Energy levels.  Can be found for free atoms in, e.g., T. A. Carlson.
+  // Photoelectron and Auger Spectroscopy. Plenum Press, New York and London,
+  // 1985. Available in a convenient form in G4AtomicShells.cc.
+  //
+  // Sternheimer 1984 implies that the energy level for conduction electrons
+  // (the final element of this array) should be set to zero, although the
+  // computation could be run with other values.
+  double * levE;
+
+  // The plasma energy of the material in eV, which is simply
+  // 28.816 sqrt(density Z/A), with density in g/cc.
+  double plasmaE;
+
+  // The mean excitation energy of the material in eV, i.e. the 'I' in the
+  // Bethe energy loss formula.
+  double meanexcite;
+
+
+  /***** Results of intermediate calculations *****/
+
+  // The Sternheimer parameters l_i which appear in Sternheimer 1984 eq(1).
+  double * sternl;
+
+  // The adjusted energy levels, as found using Sternheimer 1984 eq(8).
+  double * sternEbar;
+
+
+  /***** Packaged for convenience *****/
+
+  // The Sternheimer 'x' defined as log10(p/m) == log10(beta*gamma).
+  // This is packaged with the rest of the data for convenience.
+  // Any value set here is overwritten when the user calls DoFermiDeltaCalc().
+  double sternx;
+};
+
+/**
+ * Given a material defined in 'par' with a plasma energy, mean excitation
+ * energy, and set of atomic energy levels ("oscillator frequencies") with
+ * occupation fractions ("oscillation strengths"), solve for the Sternheimer
+ * adjustment factor (Sternheimer 1984 eq 8) and record (into 'par') the values
+ * of the adjusted oscillator frequencies and Sternheimer constants l_i.
+ * After doing this, 'par' is ready for a calculation of delta for an
+ * arbitrary particle energy.  Returns true on success, false on failure.
+ */
+bool SetupFermiDeltaCalc(G4DensityEffectCalcData * par);
+
+/**
+ * Given that SetupFermiDeltaCalc() has already been called, calculate
+ * the Fermi density effect delta for a given Sternheimer x, defined as
+ * log10(beta * gamma).  This can be called any number of times without
+ * rerunning SetupFermiDeltaCalc().
+ *
+ * Physically, delta is always non-negative.  Returns -1 on failure.
+ */
+double DoFermiDeltaCalc(G4DensityEffectCalcData * par,
+                        const double sternx);
+
+#endif

--- a/source/materials/sources.cmake
+++ b/source/materials/sources.cmake
@@ -73,6 +73,7 @@ GEANT4_DEFINE_MODULE(NAME G4materials
 			G4UCNMicroRoughnessHelper.hh
 			G4VIonDEDXTable.hh
 			G4VMaterialExtension.hh
+			G4DensityEffectCalc.hh
     SOURCES
 			G4AtomicBond.cc
 			G4AtomicFormFactor.cc
@@ -105,6 +106,7 @@ GEANT4_DEFINE_MODULE(NAME G4materials
 			G4UCNMaterialPropertiesTable.cc
 			G4UCNMicroRoughnessHelper.cc
 			G4VIonDEDXTable.cc
+			G4DensityEffectCalc.cc
     GRANULAR_DEPENDENCIES
         G4globman
         G4intercoms

--- a/source/materials/src/G4DensityEffectCalc.cc
+++ b/source/materials/src/G4DensityEffectCalc.cc
@@ -1,0 +1,258 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+
+/*
+ * Implements calculation of the Fermi density effect as per the method
+ * described in:
+ *
+ *   R. M. Sternheimer, M. J. Berger, and S. M. Seltzer. Density
+ *   effect for the ionization loss of charged particles in various sub-
+ *   stances. Atom. Data Nucl. Data Tabl., 30:261, 1984.
+ *
+ * Which (among other Sternheimer references) builds on:
+ *
+ *   R. M. Sternheimer. The density effect for ionization loss in
+ *   materials. Phys. Rev., 88:851­859, 1952.
+ *
+ * The returned values of delta are directly from the Sternheimer calculation,
+ * and not Sternheimer's popular three-part approximate parameterization
+ * introduced in the same paper.
+ *
+ * Author: Matthew Strait <straitm@umn.edu> 2019
+ */
+
+#include "G4ios.hh"
+#include "G4DensityEffectCalc.hh"
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+/* Newton's method for finding roots.  Adapted from G4PolynominalSolver, but
+ * without the assumption that the input is a polynomial.  Also, here we
+ * always expect the roots to be positive, so return -1 as an error value. */
+static double newton(const double start,
+                     double(*Function)(double, G4DensityEffectCalcData *),
+                     double(*Derivative)(double, G4DensityEffectCalcData *),
+                     G4DensityEffectCalcData * par)
+{
+  const int maxIter = 100;
+
+  int nbad = 0, ngood = 0;
+
+  double Lambda = start;
+
+  while(true){
+    const double Value = Function(Lambda, par);
+    const double Gradient = Derivative(Lambda, par);
+    Lambda -= Value/Gradient;
+
+    if(std::fabs((Value/Gradient)/Lambda) <= 1e-12) {
+      ngood++;
+      if(ngood == 2) return Lambda;
+    } else {
+      nbad++;
+      if(nbad > maxIter || isnan(Value) || isinf(Value)) return -1;
+    }
+  }
+}
+
+/* Return the derivative of the equation used
+ * to solve for the Sternheimer parameter rho. */
+static double dfrho(double rho, G4DensityEffectCalcData * p)
+{
+  double ans = 0;
+  for(int i = 0; i < p->nlev-1; i++)
+    if(p->sternf[i] > 0)
+      ans += p->sternf[i] * pow(p->levE[i], 2) * rho /
+        (pow(p->levE[i] * rho, 2) + 2./3. * p->sternf[i] * pow(p->plasmaE, 2));
+
+  return ans;
+}
+
+/* Return the functional value for the equation used
+ * to solve for the Sternheimer parameter rho. */
+static double frho(double rho, G4DensityEffectCalcData * p)
+{
+  double ans = 0;
+  for(int i = 0; i < p->nlev-1; i++)
+    if(p->sternf[i] > 0)
+      ans += p->sternf[i] * log(pow(p->levE[i]*rho, 2) +
+        2./3. * p->sternf[i]*pow(p->plasmaE, 2));
+
+  ans *= 0.5; // pulled out of loop for efficiency
+
+  if(p->sternf[p->nlev-1] > 0)
+    ans += p->sternf[p->nlev-1] * log(p->plasmaE * sqrt(p->sternf[p->nlev-1]));
+
+  ans -= log(p->meanexcite);
+
+  return ans;
+}
+
+/* Return the derivative for the equation used to
+ * solve for the Sternheimer parameter l, called 'L' here. */
+static double dell(double L, G4DensityEffectCalcData * p)
+{
+  double ans = 0;
+  for(int i = 0; i < p->nlev; i++)
+    if(p->sternf[i] > 0 && (p->sternEbar[i] > 0 || L != 0))
+      ans += p->sternf[i]/pow(pow(p->sternEbar[i], 2) + L*L, 2);
+
+  ans *= -2*L; // pulled out of the loop for efficiency
+
+  return ans;
+}
+
+/* Return the functional value for the equation used to
+ * solve for the Sternheimer parameter l, called 'L' here. */
+static double ell(double L, G4DensityEffectCalcData * p)
+{
+  double ans = 0;
+  for(int i = 0; i < p->nlev; i++)
+    if(p->sternf[i] > 0 && (p->sternEbar[i] > 0 || L != 0))
+      ans += p->sternf[i]/(pow(p->sternEbar[i], 2) + L*L);
+
+  ans -= pow(10, - 2 * p->sternx);
+
+  return ans;
+}
+
+/**
+ * Given the Sternheimer parameter l^2 (called 'sternL' here), and that
+ * the l_i and adjusted energies have been found with SetupFermiDeltaCalc(),
+ * return the value of delta.  Helper function for DoFermiDeltaCalc().
+ */
+static double delta_once_solved(G4DensityEffectCalcData * p,
+                                const double sternL)
+{
+  double ans = 0;
+  for(int i = 0; i < p->nlev; i++)
+    if(p->sternf[i] > 0)
+      ans += p->sternf[i] *
+        log((pow(p->sternl[i], 2) + pow(sternL, 2))/pow(p->sternl[i], 2));
+
+  ans -= pow(sternL, 2)/(1 + pow(10, 2 * p->sternx));
+  return ans;
+}
+
+/**
+ * Calculate the Sternheimer adjusted energy levels and parameters l_i given
+ * the Sternheimer parameter rho.  Helper function for SetupFermiDeltaCalc().
+ */
+static void calc_Ebarl(G4DensityEffectCalcData * par,
+                       const double sternrho)
+{
+  par->sternl    = (double *)malloc(sizeof(double)*par->nlev);
+  par->sternEbar = (double *)malloc(sizeof(double)*par->nlev);
+  for(int i = 0; i < par->nlev; i++){
+    par->sternEbar[i] = par->levE[i] * sternrho/par->plasmaE;
+    par->sternl[i] = i < par->nlev-1?
+      sqrt(pow(par->sternEbar[i], 2) + 2./3. * par->sternf[i])
+      : sqrt(par->sternf[i]);
+  }
+}
+
+/**
+ * If the "oscillator strengths" par->sternf do not add up to 1,
+ * normalize them so that they do.
+ */
+static void normalize_sternf(G4DensityEffectCalcData * par)
+{
+  double sum = 0;
+  for(int i = 0; i < par->nlev; i++) sum += par->sternf[i];
+  for(int i = 0; i < par->nlev; i++) par->sternf[i] /= sum;
+}
+
+/**
+ * At sufficiently high energy, the density effect takes on a simple
+ * form.  Also at sufficiently high energy, we run into numerical problems
+ * doing the full calculation.  In that case, return this.
+ */
+static double delta_limiting_case(G4DensityEffectCalcData * par,
+                                  const double sternx)
+{
+  return 2 * (log(par->plasmaE/par->meanexcite) + log(10.)*sternx) - 1;
+}
+
+
+/********************/
+/* Public functions */
+/********************/
+
+bool SetupFermiDeltaCalc(G4DensityEffectCalcData * par)
+{
+  normalize_sternf(par);
+
+  const double sternrho = newton(1.5, frho, dfrho, par);
+
+  // Negative values, and values much larger than unity are non-physical.
+  // Values between zero and one are also suspect, but not as clearly wrong.
+  if(sternrho <= 0 || sternrho > 100){
+    G4cerr <<
+    "*********************************************************************\n"
+    "* Warning: Could not solve for Sternheimer rho. Probably you have a *\n"
+    "* mean ionization energy which is incompatible with your            *\n"
+    "* distribution of energy levels.  Falling back to parameterization. *\n"
+    "*********************************************************************\n";
+    return false;
+  }
+
+  calc_Ebarl(par, sternrho);
+  return true;
+}
+
+double DoFermiDeltaCalc(G4DensityEffectCalcData * par,
+                        const double sternx)
+{
+  // Above beta*gamma of 10^10, the exact treatment is within machine
+  // precision of the limiting case, for ordinary solids, at least. The
+  // convergence goes up as the density goes down, but even in a pretty
+  // hard vacuum it converges by 10^20. Also, it's hard to imagine how
+  // this energy is relevant (x = 20 -> 10^19 GeV for muons). So this
+  // is mostly not here for physical reasons, but rather to avoid ugly
+  // discontinuities in the return value.
+  if(sternx > 20) return delta_limiting_case(par, sternx);
+
+  par->sternx = sternx;
+
+  // The derivative of the function we are solving for is strictly
+  // negative for positive (physical) values, so if the value at
+  // zero is less than zero, it has no solution, and there is no
+  // density effect in the Sternheimer "exact" treatment (which is
+  // still an approximation).
+  if(ell(0, par) <= 0) return 0;
+
+  // Increase initial guess until it converges.
+  int startLi;
+  for(startLi = -10; startLi < 30; startLi++){
+    const double sternL = newton(pow(2, startLi), &ell, &dell, par);
+    if(sternL != -1)
+      return delta_once_solved(par, sternL);
+  }
+
+  return -1; // Signal the caller to use the Sternheimer approximation,
+             // because we have been unable to solve the exact form.
+}

--- a/source/materials/src/G4DensityEffectCalc.cc
+++ b/source/materials/src/G4DensityEffectCalc.cc
@@ -46,6 +46,7 @@
 
 #include "G4ios.hh"
 #include "G4DensityEffectCalc.hh"
+#include "G4NistManager.hh"
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -211,21 +212,23 @@ bool SetupFermiDeltaCalc(G4DensityEffectCalcData * par)
   // Negative values, and values much larger than unity are non-physical.
   // Values between zero and one are also suspect, but not as clearly wrong.
   if(sternrho <= 0 || sternrho > 100){
-    G4cerr <<
-    "*********************************************************************\n"
-    "* Warning: Could not solve for Sternheimer rho. Probably you have a *\n"
-    "* mean ionization energy which is incompatible with your            *\n"
-    "* distribution of energy levels, or an unusually dense material.    *\n"
-    "* Falling back to parameterization.                                 *\n"
-    "*********************************************************************"
-    << G4endl
-    << "Number of levels: " << par->nlev << G4endl
-    << "Mean ionization energy: " << par->meanexcite << "eV" << G4endl
-    << "Plasma energy: " << par->plasmaE << "eV" << G4endl;
-    for(int i = 0; i < par->nlev; i++)
-      G4cerr << "Level " << i
-             << ": strength " << par->sternf[i]
-             << ": energy " << par->levE[i] << "eV" << G4endl;
+    if(G4NistManager::Instance()->GetVerbose() > -1){
+      G4cerr <<
+      "*********************************************************************\n"
+      "* Warning: Could not solve for Sternheimer rho. Probably you have a *\n"
+      "* mean ionization energy which is incompatible with your            *\n"
+      "* distribution of energy levels, or an unusually dense material.    *\n"
+      "* Falling back to parameterization.                                 *\n"
+      "*********************************************************************"
+      << G4endl
+      << "Number of levels: " << par->nlev << G4endl
+      << "Mean ionization energy: " << par->meanexcite << "eV" << G4endl
+      << "Plasma energy: " << par->plasmaE << "eV" << G4endl;
+      for(int i = 0; i < par->nlev; i++)
+        G4cerr << "Level " << i
+               << ": strength " << par->sternf[i]
+               << ": energy " << par->levE[i] << "eV" << G4endl;
+    }
     return false;
   }
 

--- a/source/materials/src/G4DensityEffectCalc.cc
+++ b/source/materials/src/G4DensityEffectCalc.cc
@@ -215,8 +215,17 @@ bool SetupFermiDeltaCalc(G4DensityEffectCalcData * par)
     "*********************************************************************\n"
     "* Warning: Could not solve for Sternheimer rho. Probably you have a *\n"
     "* mean ionization energy which is incompatible with your            *\n"
-    "* distribution of energy levels.  Falling back to parameterization. *\n"
-    "*********************************************************************\n";
+    "* distribution of energy levels, or an unusually dense material.    *\n"
+    "* Falling back to parameterization.                                 *\n"
+    "*********************************************************************"
+    << G4endl
+    << "Number of levels: " << par->nlev << G4endl
+    << "Mean ionization energy: " << par->meanexcite << "eV" << G4endl
+    << "Plasma energy: " << par->plasmaE << "eV" << G4endl;
+    for(int i = 0; i < par->nlev; i++)
+      G4cerr << "Level " << i
+             << ": strength " << par->sternf[i]
+             << ": energy " << par->levE[i] << "eV" << G4endl;
     return false;
   }
 

--- a/source/materials/src/G4IonisParamMat.cc
+++ b/source/materials/src/G4IonisParamMat.cc
@@ -499,6 +499,7 @@ void G4IonisParamMat::SetSternheimerExactDensityEffect()
 
   fCalcDensity->sternf = (double *)malloc(sizeof(double) * fCalcDensity->nlev);
   fCalcDensity->levE   = (double *)malloc(sizeof(double) * fCalcDensity->nlev);
+  memset(fCalcDensity->sternf, 0, sizeof(double)*fCalcDensity->nlev);
   memset(fCalcDensity->levE, 0, sizeof(double)*fCalcDensity->nlev);
 
   int sh = 0;
@@ -516,7 +517,7 @@ void G4IonisParamMat::SetSternheimerExactDensityEffect()
       // band, regardless of element.
       const int lev = i < nshell-1 || !isconductor? sh: fCalcDensity->nlev-1;
       fCalcDensity->sternf[lev] += numberfracs[j] *
-        double(G4AtomicShells::GetNumberOfElectrons(Z[j], i))/Z[j];
+        double(G4AtomicShells::GetNumberOfElectrons(Z[j], i));
       fCalcDensity->levE[lev] = G4AtomicShells::GetBindingEnergy(Z[j], i)/eV;
       sh++;
     }

--- a/source/materials/src/G4IonisParamMat.cc
+++ b/source/materials/src/G4IonisParamMat.cc
@@ -662,9 +662,11 @@ G4double G4IonisParamMat::DensityCorrection(G4double x)
   if(fCalcDensity != nullptr){
     const double exact = DoFermiDeltaCalc(fCalcDensity, x);
     if(approx > 0 && exact < 0){
-      G4cerr << "Error: Sternheimer fit failed for "
-        << fMaterial->GetName() << ". x = " << x << ": Delta = "
-        << exact << " exact " << approx  << " approx" << G4endl;
+      if(G4NistManager::Instance()->GetVerbose() > -1){
+        G4cerr << "Error: Sternheimer fit failed for "
+          << fMaterial->GetName() << ". x = " << x << ": Delta = "
+          << exact << " exact " << approx  << " approx" << G4endl;
+      }
       return approx;
     }
 
@@ -674,9 +676,11 @@ G4double G4IonisParamMat::DensityCorrection(G4double x)
     // have seen this clearly-wrong result occur for substances with extremely
     // low density (1e-25 g/cc).
     if(approx >= 0 && fabs(exact - approx) > 1){
+      if(G4NistManager::Instance()->GetVerbose() > 0){
       G4cerr << "Error: Sternheimer exact, " << exact << ", and approx, "
         << approx << " are too different for "
         << fMaterial->GetName() << ", x = " << x << G4endl;
+      }
       return approx;
     }
     return exact;

--- a/source/processes/electromagnetic/highenergy/src/G4mplIonisationModel.cc
+++ b/source/processes/electromagnetic/highenergy/src/G4mplIonisationModel.cc
@@ -202,7 +202,7 @@ G4double G4mplIonisationModel::ComputeDEDXAhlen(const G4Material* material,
 
   dedx += 0.5 * k - B[nmpl];
 
-  // density effect correction
+  // Sternheimer 3-part approximate density effect correction
   G4double deltam;
   G4double x = log(bg2) / twoln10;
   if ( x >= x0den ) {


### PR DESCRIPTION
[I don't know whether this is an official place to submit patches, so I am also
opening a Bugzilla issue.]

Added calculation of the Fermi density effect using atomic data as
described in R.M. Sternheimer et al. "Density Effect For The Ionization Loss
of Charged Particles in Various Substances" Atom. Data Nucl. Data Tabl. 30
(1984) 261-271.

This calculation gives values for the density effect 'delta' which are much
more accurate than that provided by the Sternheimer 3-part approximation,
introduced in his 1952 paper, Phys.Rev. 88 851-859.  This is particularly
true when using the general method for producing parameter
values given in his 1971 paper, Phys.Rev. B3 3681-3692, but doing the
full calculation is still a significant improvement over using the
tabulated values given in the 1984 paper for elements and a selected
set of mixtures and compounds.

The purpose of the 3-part approximation was to avoid heavy computation from
the perspective of sliderules (1952) or minicomputers (1971).  It
is no longer necessary.  I ran tests using the NOvA simulation framework and
could measure no difference in performance between using the approximation
and the full treatment.

A major advantage of this method is that the stopping power of a substance
does not abruptly change when the user modifies it so that it is no
longer a tabulated material.  In our case, we noticed this effect when
we changed iron to steel (98% iron, 2% other).  Previously, iron got
the 1984 tabulated values while steel got the 1971 general form, which
gives up to a 1.3% difference in mean muon range, with the largest
difference at about 200MeV.

I have tested the code with muons in iron and verified that the mean range
changes as expected between the approximate and exact forms.

Implementation notes:

* The calculation involves finding roots and can fail.  In this case, the
code falls back to the approximation and prints a message saying it has
done so.  I have not found any cases that prompt a failure, but have only
tested with materials found in and around the NOvA detector.

* Attempted to make clear in places that refer to the parameterization,
such as G4IonisParamMat::SetDensityEffectParameters(), that these calls only
have any effect if the full calculation fails.

* I found a separate implementation of the Sternheimer parameterization in
source/processes/electromagnetic/highenergy/src/G4mplIonisationModel.cc
I don't know why this parallel implementation exists, so I simply changed
a comment to make it more clear that it was the approximate form.

* G4IonisParamMat::DensityCorrection() is no longer inlined.

* Removed debugging print statements in G4IonisParamMat::ComputeDensityEffect().