### PR TITLE
Surface finding faster (vector->map)

### DIFF
--- a/source/geometry/volumes/include/G4LogicalBorderSurface.hh
+++ b/source/geometry/volumes/include/G4LogicalBorderSurface.hh
@@ -50,7 +50,7 @@
 class G4VPhysicalVolume;
 class G4LogicalBorderSurface;
 
-typedef std::vector<G4LogicalBorderSurface*> G4LogicalBorderSurfaceTable;
+typedef std::map<std::pair<const G4VPhysicalVolume*,const  G4VPhysicalVolume*>, G4LogicalBorderSurface*> G4LogicalBorderSurfaceTable;
 
 class G4LogicalBorderSurface : public G4LogicalSurface
 {

--- a/source/geometry/volumes/src/G4LogicalBorderSurface.cc
+++ b/source/geometry/volumes/src/G4LogicalBorderSurface.cc
@@ -38,6 +38,8 @@
 //
 // ----------------------------------------------------------------------
 
+#include <map>
+
 #include "G4LogicalBorderSurface.hh"
 #include "G4VPhysicalVolume.hh"
 
@@ -62,7 +64,7 @@ G4LogicalBorderSurface(const G4String& name,
 
   // Store in the table of Surfaces
   //
-  theBorderSurfaceTable->push_back(this);
+  theBorderSurfaceTable->insert(std::make_pair(std::make_pair(vol1,vol2),this));
 }
 
 G4LogicalBorderSurface::
@@ -143,12 +145,8 @@ G4LogicalBorderSurface::GetSurface(const G4VPhysicalVolume* vol1,
 {
   if (theBorderSurfaceTable)
   {
-    for (size_t i=0; i<theBorderSurfaceTable->size(); i++)
-    {
-      if( ((*theBorderSurfaceTable)[i]->GetVolume1() == vol1) &&
-          ((*theBorderSurfaceTable)[i]->GetVolume2() == vol2) )
-        return (*theBorderSurfaceTable)[i];
-    }
+    auto foundSurf = theBorderSurfaceTable->find(std::make_pair(vol1,vol2));
+    if(foundSurf != theBorderSurfaceTable->end()) return foundSurf->second;
   }
   return 0;
 }
@@ -162,9 +160,9 @@ void G4LogicalBorderSurface::DumpInfo()
 
   if (theBorderSurfaceTable)
   {
-    for (size_t i=0; i<theBorderSurfaceTable->size(); i++)
+    for (auto it = theBorderSurfaceTable->begin(); it!= theBorderSurfaceTable->end(); ++it)
     {
-      G4LogicalBorderSurface* pBorderSurface = (*theBorderSurfaceTable)[i];
+      G4LogicalBorderSurface* pBorderSurface = it->second;
       G4cout << pBorderSurface->GetName() << " : " << G4endl
              << " Border of volumes "
              << pBorderSurface->GetVolume1()->GetName() << " and " 
@@ -183,7 +181,7 @@ void G4LogicalBorderSurface::CleanSurfaceTable()
     for(pos=theBorderSurfaceTable->begin();
         pos!=theBorderSurfaceTable->end(); pos++)
     {
-      if (*pos)  { delete *pos; }
+      if (pos->second)  { delete pos->second; }
     }
     theBorderSurfaceTable->clear();
   }

--- a/source/persistency/gdml/src/G4GDMLWriteStructure.cc
+++ b/source/persistency/gdml/src/G4GDMLWriteStructure.cc
@@ -348,10 +348,9 @@ G4GDMLWriteStructure::GetBorderSurface(const G4VPhysicalVolume* const pvol)
   {
     const G4LogicalBorderSurfaceTable* btable =
           G4LogicalBorderSurface::GetSurfaceTable();
-    std::vector<G4LogicalBorderSurface*>::const_iterator pos;
-    for (pos = btable->begin(); pos != btable->end(); pos++)
+    for (auto pos : btable)
     {
-      if (pvol == (*pos)->GetVolume1())  // just the first in the couple 
+      if (pvol == pos->first.first)  // just the first in the couple 
       {                                  // is enough
         surf = *pos; break;
       }


### PR DESCRIPTION
This change improves performance when the number of G4LogicalBorderSurfaces is large.

The G4LogicalBorderSurfaceTable is searched frequently in optical photon simulations. When this table is large because many border surfaces have been defined, the performance of that search can dominate the performance of the simulation as a whole. The table can easily become large since border surfaces are defined between physical volumes and it's common for there to be many PhysVolume copies of the same logical volume.

This change improves performance of this search by changing the type of the G4LogicalBorderSurfaceTable from
 std::vector<G4LogicalBorderSurface*> 
to
std::map<std::pair<const G4VPhysicalVolume*,const  G4VPhysicalVolume*>, G4LogicalBorderSurface*>
since that matches the most common way this table is searched.

This change affects one area outside the internal behavior of G4LogicalBorderSurface, which is in the GDML output of border surfaces. I have some concerns because the GDML search through the border surfaces searches only by the first PhysVolume in the pair that defines the border surface. Might this result in GDML output that misses the fact that multiple BorderSurfaces can be defined from the same PhysVolume? I have left the current behavior of the GDML output unchanged, but it should be examined.