### PR TITLE
Added getters for source volume confinement status

### DIFF
--- a/source/event/include/G4SPSPosDistribution.hh
+++ b/source/event/include/G4SPSPosDistribution.hh
@@ -212,6 +212,8 @@ public:
   const G4ThreeVector& GetRotx() const {return Rotx;}
   const G4ThreeVector& GetRoty() const {return Roty;}
   const G4ThreeVector& GetRotz() const {return Rotz;}
+  G4bool GetConfined() const { return Confine; }
+  G4String GetConfineVolume() const { return VolName; }
 
     G4ThreeVector GetSideRefVec1() const;
     G4ThreeVector GetSideRefVec2() const;


### PR DESCRIPTION
For my application it was important to know when the user has confined the source to a given volume, but the existing position distribution object doesn't expose a way to read VolName or the bool Confine.  Offering the change here as its a minor header-only change and I'm likely not the only end user who can benefit from it.