### PR TITLE
Replaced deprecated std::binary_function instances with lambdas.

### DIFF
--- a/source/geometry/management/include/G4SmartVoxelStat.hh
+++ b/source/geometry/management/include/G4SmartVoxelStat.hh
@@ -41,7 +41,6 @@
 #define G4SmartVoxelStat_hh
 
 #include "G4Types.hh"
-#include <functional>
 
 class G4LogicalVolume;
 class G4SmartVoxelHeader;
@@ -97,32 +96,7 @@ class G4SmartVoxelStat
     G4long heads;
     G4long nodes;
     G4long pointers;
-  
-  
-  public:
-  
-    //
-    // Functor objects for sorting
-    //
-    struct ByCpu
-      : public std::binary_function< const G4SmartVoxelStat,
-                                     const G4SmartVoxelStat, G4bool >
-    {
-      G4bool operator()( const G4SmartVoxelStat &a, const G4SmartVoxelStat &b )
-      {
-        return a.GetTotalTime() > b.GetTotalTime();
-      }
-    };
-  
-    struct ByMemory
-      : public std::binary_function< const G4SmartVoxelStat,
-                                     const G4SmartVoxelStat, G4bool >
-    {
-      G4bool operator()( const G4SmartVoxelStat &a, const G4SmartVoxelStat &b )
-      {
-        return a.GetMemoryUse() > b.GetMemoryUse();
-      }
-    };
+
 };
 
 #endif

--- a/source/geometry/management/src/G4GeometryManager.cc
+++ b/source/geometry/management/src/G4GeometryManager.cc
@@ -383,7 +383,8 @@ G4GeometryManager::ReportVoxelStats( std::vector<G4SmartVoxelStat> & stats,
   //
   // First list: sort by total CPU time
   //
-  std::sort( stats.begin(), stats.end(), G4SmartVoxelStat::ByCpu() );
+  std::sort( stats.begin(), stats.end(), [](const G4SmartVoxelStat& a, const G4SmartVoxelStat& b){
+      return a.GetTotalTime() > b.GetTotalTime(); });
          
   G4int nPrint = nStat > 10 ? 10 : nStat;
 
@@ -424,7 +425,9 @@ G4GeometryManager::ReportVoxelStats( std::vector<G4SmartVoxelStat> & stats,
   //
   // Second list: sort by memory use
   //
-  std::sort( stats.begin(), stats.end(), G4SmartVoxelStat::ByMemory() );
+  std::sort( stats.begin(), stats.end(), [](const G4SmartVoxelStat& a, const G4SmartVoxelStat& b){
+      return a.GetMemoryUse() > b.GetMemoryUse();
+    } );
  
   if (nPrint)
   {

--- a/source/processes/hadronic/models/de_excitation/multifragmentation/include/G4StatMFMicroCanonical.hh
+++ b/source/processes/hadronic/models/de_excitation/multifragmentation/include/G4StatMFMicroCanonical.hh
@@ -109,23 +109,6 @@ private:
     }
   };
 
-  class SumProbabilities : public std::binary_function<G4double,G4double,G4double>
-  {
-  public:
-    SumProbabilities() : total(0.0) {}
-    G4double operator() (G4double& /* probSoFar*/, G4StatMFMicroManager*& manager)
-    { 
-      total += manager->GetProbability();
-      return total;
-    }
-    
-    G4double GetTotal() { return total; }
-  public:
-    G4double total;
-    
-  };
-
-
 };
 
 #endif

--- a/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFChannel.cc
+++ b/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFChannel.cc
@@ -43,21 +43,6 @@
 #include "G4Exp.hh"
 #include "G4RandomDirection.hh"
 
-class SumCoulombEnergy : public std::binary_function<G4double,G4double,G4double>
-{
-public:
-  SumCoulombEnergy() : total(0.0) {}
-  G4double operator() (G4double& , G4StatMFFragment*& frag)
-  { 
-      total += frag->GetCoulombEnergy();
-      return total;
-  }
-    
-  G4double GetTotal() { return total; }
-public:
-  G4double total;  
-};
-
 G4StatMFChannel::G4StatMFChannel() : 
   _NumOfNeutralFragments(0), 
   _NumOfChargedFragments(0)
@@ -103,7 +88,10 @@ void G4StatMFChannel::CreateFragment(G4int A, G4int Z)
 G4double G4StatMFChannel::GetFragmentsCoulombEnergy(void)
 {
   G4double Coulomb = std::accumulate(_theFragments.begin(),_theFragments.end(),
-				     0.0,SumCoulombEnergy());
+                                    0.0,
+                                    [](const G4double& running_total, G4StatMFFragment*& fragment) {
+                                        return running_total + fragment->GetCoulombEnergy(); }
+                                    );
   //      G4double Coulomb = 0.0;
   //      for (unsigned int i = 0;i < _theFragments.size(); i++)
   //  	Coulomb += _theFragments[i]->GetCoulombEnergy();

--- a/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFMicroCanonical.cc
+++ b/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFMicroCanonical.cc
@@ -115,7 +115,10 @@ void G4StatMFMicroCanonical::Initialize(const G4Fragment & theFragment)
   // W is the total probability
   W = std::accumulate(_ThePartitionManagerVector.begin(),
 		      _ThePartitionManagerVector.end(),
-		      W, SumProbabilities());
+		      W,
+		      [](const G4double& running_total, G4StatMFMicroManager*& manager) {
+		         return running_total + manager->GetProbability();
+		      });
   
   // Normalization of statistical weights
   for (it =  _ThePartitionManagerVector.begin(); it !=  _ThePartitionManagerVector.end(); ++it) 


### PR DESCRIPTION
std::binary_function was deprecated in C++11 and has been removed in C++17. C++17 projects including Geant4 headers will not build.

There were three classes in the code base deriving from std::binary_function. These were all one-off usages for calling std::sort or std::accumulate. It is very unlikely that they were used by third parties. They can probably be replaced with lambdas; if these objects are still needed in the public API, the simplest choice is replacing them with static functions e.g. ByCpu becomes:

`    static G4bool ByCPU(( const G4SmartVoxelStat &a, const G4SmartVoxelStat &b )
      {
        return a.GetMemoryUse() > b.GetMemoryUse();
      }`
