### PR TITLE
Add CMake option to build fully statically linked libraries on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 #-----------------------------------------------------------------------
 # - Define CMake requirements and override make rules as needed
 #
-cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 # - Any policy requirements should go here
 

--- a/cmake/Modules/G4BuildSettings.cmake
+++ b/cmake/Modules/G4BuildSettings.cmake
@@ -349,6 +349,15 @@ if(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "Neither static nor shared libraries will be built")
 endif()
 
+if(MSVC)
+    option(GEANT4_MSVC_STATIC_RUNTIME "Use statically-linked multithreaded runtime library" OFF)
+    mark_as_advanced(GEANT4_MSVC_STATIC_RUNTIME)
+
+    if(GEANT4_MSVC_STATIC_RUNTIME)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "Multithreaded$<$CONFIG:Debug>:Debug>")
+    endif()
+endif()
+
 # Always build global libraries - always FATAL_ERROR if old
 # granular library switch is set, e.g. from command line
 if(GEANT4_BUILD_GRANULAR_LIBS)

--- a/cmake/Modules/G4BuildSettings.cmake
+++ b/cmake/Modules/G4BuildSettings.cmake
@@ -354,7 +354,7 @@ if(MSVC)
     mark_as_advanced(GEANT4_MSVC_STATIC_RUNTIME)
 
     if(GEANT4_MSVC_STATIC_RUNTIME)
-        set(CMAKE_MSVC_RUNTIME_LIBRARY "Multithreaded$<$CONFIG:Debug>:Debug>")
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     endif()
 endif()
 


### PR DESCRIPTION
Added advanced CMake option GEANT4_MSVC_STATIC_RUNTIME that enables linking against the static multithreaded runtime libraries. Otherwise, binaries that are statically linked against Geant4 are not fully static. Without this option, /MT and /MTd flags need to be added manually.

See:
https://cmake.org/cmake/help/v3.15/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html#variable:CMAKE_MSVC_RUNTIME_LIBRARY

NOTE: This requires bumping the required CMake version to 3.15.