### PR TITLE
Disable copying of G4PhysicalVolumeStore.

### DIFF
--- a/source/geometry/management/include/G4PhysicalVolumeStore.hh
+++ b/source/geometry/management/include/G4PhysicalVolumeStore.hh
@@ -79,6 +79,8 @@ class G4PhysicalVolumeStore : public std::vector<G4VPhysicalVolume*>
     virtual ~G4PhysicalVolumeStore();
       // Destructor: takes care to delete allocated physical volumes.
 
+    G4PhysicalVolumeStore(const G4PhysicalVolumeStore&) = delete;
+    G4VPhysicalVolume& operator=(const G4PhysicalVolumeStore&) = delete;
   protected:
 
     G4PhysicalVolumeStore();


### PR DESCRIPTION
Accidentally copying the G4PhysicalVolumeStore instance causes unexpected behaviour, and hence it should be disabled.