### PR TITLE
Expose PhysListFactory in g4py

### DIFF
--- a/environments/g4py/source/physics_lists/CMakeLists.txt
+++ b/environments/g4py/source/physics_lists/CMakeLists.txt
@@ -3,6 +3,7 @@
 # library
 geant4_add_pymodule(pyG4physicslists
   pyPhysicsLists.cc
+  pyPhysListFactory.cc
   pymodG4physicslists.cc
 )
 target_link_libraries(pyG4physicslists PRIVATE G4physicslists)

--- a/environments/g4py/source/physics_lists/pyPhysListFactory.cc
+++ b/environments/g4py/source/physics_lists/pyPhysListFactory.cc
@@ -24,22 +24,30 @@
 // ********************************************************************
 //
 // ====================================================================
-//   pymodG4physicslists.cc [Geant4Py module]
+//   pyPhysListFactory.cc
 //
-//                                         2005 Q
+//                                         2020 Q
 // ====================================================================
 #include <boost/python.hpp>
+#include "G4PhysListFactory.hh"
 
 using namespace boost::python;
 
 // ====================================================================
 // module definition
 // ====================================================================
-void export_PhysicsLists();
-void export_PhysListFactory();
-
-BOOST_PYTHON_MODULE(G4physicslists)
+void export_PhysListFactory()
 {
-  export_PhysicsLists();
-  export_PhysListFactory();
+  class_<G4PhysListFactory, G4PhysListFactory*>
+    ("G4PhysListFactory", "phys list factory")
+    .def("GetReferencePhysList", &G4PhysListFactory::GetReferencePhysList,
+         return_internal_reference<>())
+    .def("ReferencePhysList", &G4PhysListFactory::ReferencePhysList,
+         return_internal_reference<>())
+    .def("IsReferencePhysList", &G4PhysListFactory::IsReferencePhysList)
+    .def("AvailablePhysLists", &G4PhysListFactory::AvailablePhysLists,
+	 return_value_policy<reference_existing_object>())
+    .def("AvailablePhysListsEM", &G4PhysListFactory::AvailablePhysListsEM,
+	 return_value_policy<reference_existing_object>())
+    ;
 }


### PR DESCRIPTION
This exposes the `PhysListFactory` in the `g4py` environment. This was useful when wanting to use non-standard EM physics lists with the available reference lists (e.g., `FTFP_BERT_LIV`).