### PR TITLE
Fix installation error with brew GL package

### DIFF
--- a/cmake/Modules/FindXQuartzGL.cmake
+++ b/cmake/Modules/FindXQuartzGL.cmake
@@ -49,17 +49,17 @@ set(CMAKE_FIND_FRAMEWORK_SAVE ${CMAKE_FIND_FRAMEWORK})
 set(CMAKE_FIND_FRAMEWORK NEVER)
 
 find_path(XQuartzGL_INCLUDE_DIR GL/gl.h
-  PATHS /usr/X11R6/include /opt/X11/include
+  PATHS /usr/X11R6/include /opt/X11/include /usr/local/include
   NO_DEFAULT_PATH
   )
 
 find_library(XQuartzGL_gl_LIBRARY GL
-  PATHS /usr/X11R6/lib /opt/X11/lib
+  PATHS /usr/X11R6/lib /opt/X11/lib /usr/local/lib
   NO_DEFAULT_PATH
   )
 
 find_library(XQuartzGL_glu_LIBRARY GLU
-  PATHS /usr/X11R6/lib /opt/X11/lib
+  PATHS /usr/X11R6/lib /opt/X11/lib /usr/local/lib
   NO_DEFAULT_PATH
   )
 


### PR DESCRIPTION
The brew package manager for macosx supports meanwhile the installation of
x11 and GL and is not longer bound to the usage of the unsupported XQuartz
package. Using the brew packages libx11 and mesa-glu the necessary include
and library files are ínstalled in /usr/local. Unfortunately this directory
is not in the search path such that the configuration of Geant4 fails.
The fix add the the missing search path such that GL installation is found
and the configuration succeeds.