### PR TITLE
minor fix in gdml code

### DIFF
--- a/source/persistency/gdml/src/G4GDMLParser.cc
+++ b/source/persistency/gdml/src/G4GDMLParser.cc
@@ -83,10 +83,9 @@ G4GDMLParser::~G4GDMLParser()
   if(!uwcode)
   {
     delete writer;
-    delete ullist;
-    delete rlist;
   }
-
+  delete ullist;
+  delete rlist;
   delete messenger;
 }
 
@@ -98,7 +97,7 @@ void G4GDMLParser::ImportRegions()
   for(auto iaux = auxInfoList->cbegin(); iaux != auxInfoList->cend(); ++iaux)
   {
     if(iaux->type != "Region")
-      return;
+      continue;
 
     G4String name = iaux->value;
     if(strip)


### PR DESCRIPTION
Auxilary info may contain other info, returning at early stage when loading regions seem inappropriate.

The two lists are used to write the region exports in the process of serialization, and does not seem to be influenced by whatever serializer it's using.