### PR TITLE
Some fixes in the Win32 OpenGL driver

### DIFF
--- a/source/interfaces/basic/src/G4UIExecutive.cc
+++ b/source/interfaces/basic/src/G4UIExecutive.cc
@@ -286,6 +286,10 @@ void G4UIExecutive::SelectSessionByFile(const G4String& appname)
 void G4UIExecutive::SelectSessionByBestGuess()
 {
   if ( qt_build ) selected = kQt;
+#ifdef WIN32
+  // Ensure that in Windows 'win32' is selected as second choice (Ovidio Pena, 2021/02/24)
+  else if ( win32_build ) selected = kWin32;
+#endif
   else if ( tcsh_build ) selected = kTcsh;
   else if ( xm_build ) selected = kXm;
 }

--- a/source/visualization/OpenGL/include/G4OpenGLWin32Viewer.hh
+++ b/source/visualization/OpenGL/include/G4OpenGLWin32Viewer.hh
@@ -57,8 +57,19 @@ private:
   static LRESULT CALLBACK WindowProc(HWND,UINT,WPARAM,LPARAM);
   static bool SetWindowPixelFormat(HDC);
 private:
+  void TrackMouse(G4int, G4int);
+  void ReleaseMouse();
+  void SetShift(G4int, G4int);
+  void SetRotation(G4int, G4int);
+  void SetZoom(G4int);;
+private:
   HWND fWindow;
   HGLRC fHGLRC;
+
+protected:
+  G4bool fMouseHovered;
+  G4bool fMousePressed;
+  G4int fMousePressedX, fMousePressedY;
 };
 
 #endif


### PR DESCRIPTION
I have implemented the **WindowProc** function in the Win32 OpenGL driver (it was commented). Now it is possible to change the Zoom and the orientation using the mouse (like in the Qt driver). Moreover, I have changed **G4UIExecutive** to ensure that in Windows the  Win32 OpenGL driver is selected as the second choice by default.