### PR TITLE
Update gui.mac

### DIFF
--- a/examples/advanced/STCyclotron/Macro/GUI/gui.mac
+++ b/examples/advanced/STCyclotron/Macro/GUI/gui.mac
@@ -7,7 +7,7 @@
 # Add icons of general interest
 #
 /control/execute Macro/GUI/icons.mac
-/control/execute Macro/init_beam.mac
+/control/execute Macro/init_parameters.mac
 
 # File menu :
 /gui/addMenu file File


### PR DESCRIPTION
Changed /control/execute Macro/init_beam.mac to /control/execute Macro/init_parameters.mac

init_beam.mac does not exist, application fails to run with gui.mac due to this initialisation error.