### PR TITLE
Avoid possible buffer overflow in G4strstreambuf

### DIFF
--- a/source/global/management/include/G4strstreambuf.icc
+++ b/source/global/management/include/G4strstreambuf.icc
@@ -42,8 +42,11 @@ inline G4strstreambuf::~G4strstreambuf()
 {
   // flushing buffer...
   // std::cout is used because destination object may not be alive.
-  if(count != 0)
+  if(count != 0 and count <= size) {
+    // make sure the buffer has a 0 byte at the end
+    buffer[count] = 0;
     std::cout << buffer;
+  }
 
   delete[] buffer;
 }


### PR DESCRIPTION
On shutdown there's no guarantee that there's a 0 byte at the end of the string as the 0 is only added just before printing. So in the worst case the whole buffer could be non-zero and we print memory not outside the buffer until a zero is found. Could also just cause random garbage to be printed.