### PR TITLE
Fixed syntax errors in "microelectronics" example.

### DIFF
--- a/examples/advanced/microelectronics/plot.C
+++ b/examples/advanced/microelectronics/plot.C
@@ -10,17 +10,18 @@ gROOT->SetStyle("Plain");
 Double_t scale;
 	
 c1 = new TCanvas ("c1","",20,20,1000,500);
-c1.Divide(2,1);
+c1->Divide(2,1);
 
-system ("rm -rf microelectronics.root");
-system ("hadd microelectronics.root microelectronics_*.root");
+//system ("rm -rf microelectronics.root");
+//system ("hadd microelectronics.root microelectronics_*.root");
 
-TFile f("microelectronics.root"); 
+// Running ./microelectronics will generate this file
+TFile f("microelectronics.root");
 
 TNtuple* ntuple;
-ntuple = (TNtuple*)f->Get("microelectronics"); 
+ntuple = (TNtuple*)f.Get("microelectronics");
      
-c1.cd(1);
+c1->cd(1);
   gStyle->SetOptStat(000000);
   
   // All
@@ -37,7 +38,7 @@ c1.cd(1);
   
   gPad->SetLogy();
 
-c1.cd(2);
+c1->cd(2);
 
   // Electrons
   ntuple->SetMarkerColor(2);


### PR DESCRIPTION
While the Geant4 example compiles and runs fine, the included ROOT script has a few syntactic errors that must be fixed before it can be executed.

I also removed two lines that delete previously generated results. I'm not sure what setup was intended here. But the way it is changed in this patch, the example (including the ROOT plot script) now works out of the box and no longer requires changes in the code.