### PR TITLE
Use exact version of python for python boost module in CMakeLists.txt

### DIFF
--- a/environments/g4py/CMakeLists.txt
+++ b/environments/g4py/CMakeLists.txt
@@ -8,7 +8,7 @@
 # which Python an install of Boost Python uses)...
 find_package(PythonInterp 3.0 REQUIRED)
 find_package(PythonLibs REQUIRED)
-find_package(Boost 1.65 REQUIRED python)
+find_package(Boost 1.65 REQUIRED python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
 
 # Variables and Functions to help build, organise, and install modules
 include(${CMAKE_CURRENT_SOURCE_DIR}/G4PythonHelpers.cmake)

--- a/environments/g4py/G4PythonHelpers.cmake
+++ b/environments/g4py/G4PythonHelpers.cmake
@@ -40,7 +40,7 @@ function(g4py_add_module target_name)
   # Use dynamic_lookup on Darwin to avoid direct linking to libpython (Linux has this as default,
   # to be checked for Windows)
   target_include_directories(${target_name} PRIVATE ${PYTHON_INCLUDE_DIRS})
-  target_link_libraries(${target_name} PRIVATE Boost::python "$<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>")
+  target_link_libraries(${target_name} PRIVATE Boost::python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} "$<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>")
 
   # Workaround to suppress pragma message spam in Boost >= 1.73
   # - See https://github.com/boostorg/python/pull/315


### PR DESCRIPTION
Requires exact version for the python boost module,
see examples in 
https://cmake.org/cmake/help/latest/module/FindBoost.html