### PR TITLE
Allow "SetHistoDirectoryName" and "SetNtupleDirectoryName" to work with xml, csv

### DIFF
--- a/source/analysis/csv/include/G4CsvAnalysisManager.hh
+++ b/source/analysis/csv/include/G4CsvAnalysisManager.hh
@@ -84,6 +84,7 @@ class G4CsvAnalysisManager : public G4ToolsAnalysisManager
     template <typename T>
     G4bool WriteT(const std::vector<T*>& htVector,
                   const std::vector<G4HnInformation*>& hnVector,
+                  const G4String& directoryName,
                   const G4String& hnType);
     G4bool WriteH1();
     G4bool WriteH2();

--- a/source/analysis/csv/include/G4CsvAnalysisManager.hh
+++ b/source/analysis/csv/include/G4CsvAnalysisManager.hh
@@ -28,6 +28,9 @@
 // It delegates most of functions to the object specific managers. 
 
 // Author: Ivana Hrivnacova, 18/06/2013  (ivana@ipno.in2p3.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - enabled saving to directories
 
 #ifndef G4CsvAnalysisManager_h
 #define G4CsvAnalysisManager_h 1

--- a/source/analysis/csv/include/G4CsvAnalysisManager.icc
+++ b/source/analysis/csv/include/G4CsvAnalysisManager.icc
@@ -36,6 +36,7 @@ template <>
 inline 
 G4bool G4CsvAnalysisManager::WriteT(const std::vector<tools::histo::p1d*>& htVector,
                                     const std::vector<G4HnInformation*>& hnVector,
+                                    const G4String& directoryName,
                                     const G4String& hnType)
 {
   for ( G4int i=0; i<G4int(htVector.size()); ++i ) {
@@ -46,7 +47,12 @@ G4bool G4CsvAnalysisManager::WriteT(const std::vector<tools::histo::p1d*>& htVec
     if ( fState.GetIsActivation() && ( ! activation ) ) continue; 
     auto ht = htVector[i];
     auto fileName = fFileManager->GetHnFileName(hnType, name);
-    std::ofstream hnFile(fileName);
+    G4String path = "";
+    if (!directoryName.empty()) {
+      path.append(directoryName);
+      path.append("/");
+    }
+    std::ofstream hnFile(path + fileName);
 
     // Do nothing if there is no file
     if ( ! hnFile.is_open() ) return false;
@@ -64,7 +70,7 @@ G4bool G4CsvAnalysisManager::WriteT(const std::vector<tools::histo::p1d*>& htVec
     hnFile.close();
 #ifdef G4VERBOSE
     if ( fState.GetVerboseL1() ) 
-      fState.GetVerboseL1()->Message("write", "file", fileName);
+      fState.GetVerboseL1()->Message("write", "file", path + fileName);
 #endif
   }
 
@@ -76,6 +82,7 @@ template <>
 inline 
 G4bool G4CsvAnalysisManager::WriteT(const std::vector<tools::histo::p2d*>& htVector,
                                     const std::vector<G4HnInformation*>& hnVector,
+                                    const G4String& directoryName,
                                     const G4String& hnType)
 {
   for ( G4int i=0; i<G4int(htVector.size()); ++i ) {
@@ -86,7 +93,12 @@ G4bool G4CsvAnalysisManager::WriteT(const std::vector<tools::histo::p2d*>& htVec
     if ( fState.GetIsActivation() && ( ! activation ) ) continue; 
     auto ht = htVector[i];
     auto fileName = fFileManager->GetHnFileName(hnType, name);
-    std::ofstream hnFile(fileName);
+    G4String path = "";
+    if (!directoryName.empty()) {
+      path.append(directoryName);
+      path.append("/");
+    }
+    std::ofstream hnFile(path + fileName);
 
     // Do nothing if there is no file
     if ( ! hnFile.is_open() ) return false;
@@ -104,7 +116,7 @@ G4bool G4CsvAnalysisManager::WriteT(const std::vector<tools::histo::p2d*>& htVec
     hnFile.close();
 #ifdef G4VERBOSE
     if ( fState.GetVerboseL1() ) 
-      fState.GetVerboseL1()->Message("write", "file", fileName);
+      fState.GetVerboseL1()->Message("write", "file", path + fileName);
 #endif
   }
 
@@ -116,6 +128,7 @@ template <typename T>
 inline 
 G4bool G4CsvAnalysisManager::WriteT(const std::vector<T*>& htVector,
                                     const std::vector<G4HnInformation*>& hnVector,
+                                    const G4String& directoryName,
                                     const G4String& hnType)
 {
   for ( G4int i=0; i<G4int(htVector.size()); ++i ) {
@@ -126,7 +139,12 @@ G4bool G4CsvAnalysisManager::WriteT(const std::vector<T*>& htVector,
     if ( fState.GetIsActivation() && ( ! activation ) ) continue; 
     auto ht = htVector[i];
     auto fileName = fFileManager->GetHnFileName(hnType, name);
-    std::ofstream hnFile(fileName);
+    G4String path = "";
+    if (!directoryName.empty()) {
+      path.append(directoryName);
+      path.append("/");
+    }
+    std::ofstream hnFile(path + fileName);
 
     // Do nothing if there is no file
     if ( ! hnFile.is_open() ) return false;
@@ -143,7 +161,7 @@ G4bool G4CsvAnalysisManager::WriteT(const std::vector<T*>& htVector,
     hnFile.close();
 #ifdef G4VERBOSE
     if ( fState.GetVerboseL1() ) 
-      fState.GetVerboseL1()->Message("write", "file", fileName);
+      fState.GetVerboseL1()->Message("write", "file", path + fileName);
 #endif
   }
 

--- a/source/analysis/csv/src/G4CsvAnalysisManager.cc
+++ b/source/analysis/csv/src/G4CsvAnalysisManager.cc
@@ -122,7 +122,7 @@ G4bool G4CsvAnalysisManager::WriteH1()
   auto result = true;
 
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName();
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists();
     result = WriteT(h1Vector, hnVector, directoryName, "h1");
   }  
   else {
@@ -147,7 +147,7 @@ G4bool G4CsvAnalysisManager::WriteH2()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName();
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists();
     result = WriteT(h2Vector, hnVector, directoryName, "h2");
   }  
   else {
@@ -172,7 +172,7 @@ G4bool G4CsvAnalysisManager::WriteH3()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName();
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists();
     result = WriteT(h3Vector, hnVector, directoryName, "h3");
   }  
   else {
@@ -197,7 +197,7 @@ G4bool G4CsvAnalysisManager::WriteP1()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName();
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists();
     result = WriteT(p1Vector, hnVector, directoryName, "p1");
   }  
   else {
@@ -222,7 +222,7 @@ G4bool G4CsvAnalysisManager::WriteP2()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName();
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists();
     result = WriteT(p2Vector, hnVector, directoryName, "p2");
   }  
   else {

--- a/source/analysis/csv/src/G4CsvAnalysisManager.cc
+++ b/source/analysis/csv/src/G4CsvAnalysisManager.cc
@@ -122,7 +122,8 @@ G4bool G4CsvAnalysisManager::WriteH1()
   auto result = true;
 
   if ( ! G4Threading::IsWorkerThread() )  {
-    result = WriteT(h1Vector, hnVector, "h1");
+    auto directoryName = fFileManager->GetHistoDirectoryName();
+    result = WriteT(h1Vector, hnVector, directoryName, "h1");
   }  
   else {
     // The worker manager just adds its histograms to the master
@@ -146,7 +147,8 @@ G4bool G4CsvAnalysisManager::WriteH2()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    result = WriteT(h2Vector, hnVector, "h2");
+    auto directoryName = fFileManager->GetHistoDirectoryName();
+    result = WriteT(h2Vector, hnVector, directoryName, "h2");
   }  
   else {
     // The worker manager just adds its histograms to the master
@@ -170,7 +172,8 @@ G4bool G4CsvAnalysisManager::WriteH3()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    result = WriteT(h3Vector, hnVector, "h3");
+    auto directoryName = fFileManager->GetHistoDirectoryName();
+    result = WriteT(h3Vector, hnVector, directoryName, "h3");
   }  
   else {
     // The worker manager just adds its histograms to the master
@@ -194,7 +197,8 @@ G4bool G4CsvAnalysisManager::WriteP1()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    result = WriteT(p1Vector, hnVector, "p1");
+    auto directoryName = fFileManager->GetHistoDirectoryName();
+    result = WriteT(p1Vector, hnVector, directoryName, "p1");
   }  
   else {
     // The worker manager just adds its profiles to the master
@@ -218,7 +222,8 @@ G4bool G4CsvAnalysisManager::WriteP2()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    result = WriteT(p2Vector, hnVector, "p2");
+    auto directoryName = fFileManager->GetHistoDirectoryName();
+    result = WriteT(p2Vector, hnVector, directoryName, "p2");
   }  
   else {
     // The worker manager just adds its profiles to the master

--- a/source/analysis/csv/src/G4CsvAnalysisManager.cc
+++ b/source/analysis/csv/src/G4CsvAnalysisManager.cc
@@ -25,6 +25,9 @@
 //
 
 // Author: Ivana Hrivnacova, 18/06/2013  (ivana@ipno.in2p3.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - enabled saving to directories
 
 #include "G4CsvAnalysisManager.hh"
 #include "G4CsvFileManager.hh"

--- a/source/analysis/csv/src/G4CsvFileManager.cc
+++ b/source/analysis/csv/src/G4CsvFileManager.cc
@@ -126,6 +126,14 @@ G4bool G4CsvFileManager::OpenFile(const G4String& fileName)
 G4bool G4CsvFileManager::CreateNtupleFile(
   CsvNtupleDescription* ntupleDescription)
 {
+  // set description file name so that we can properly save to directories
+  auto path = GetNtupleDirectoryName();
+  if (!path.empty()) {
+      path.append("/");
+    }
+  ntupleDescription->fFileName = path+fFileName+"_nt_"
+                                  +ntupleDescription->fNtupleBooking.name();
+
   // get ntuple file name per object (if defined)
   auto ntupleFileName = GetNtupleFileName(ntupleDescription);
 

--- a/source/analysis/csv/src/G4CsvFileManager.cc
+++ b/source/analysis/csv/src/G4CsvFileManager.cc
@@ -25,6 +25,9 @@
 //
 
 // Author: Ivana Hrivnacova, 18/06/2013  (ivana@ipno.in2p3.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - enabled saving to directories
 
 #include "G4CsvFileManager.hh"
 #include "G4CsvHnFileManager.hh"

--- a/source/analysis/csv/src/G4CsvFileManager.cc
+++ b/source/analysis/csv/src/G4CsvFileManager.cc
@@ -127,7 +127,7 @@ G4bool G4CsvFileManager::CreateNtupleFile(
   CsvNtupleDescription* ntupleDescription)
 {
   // set description file name so that we can properly save to directories
-  auto path = GetNtupleDirectoryName();
+  auto path = GetNtupleDirectoryNameIfExists();
   if (!path.empty()) {
       path.append("/");
     }

--- a/source/analysis/management/include/G4VAnalysisManager.hh
+++ b/source/analysis/management/include/G4VAnalysisManager.hh
@@ -86,6 +86,8 @@ class G4VAnalysisManager
     G4String GetFileName() const;
     G4String GetHistoDirectoryName() const;
     G4String GetNtupleDirectoryName() const;
+    G4String GetHistoDirectoryNameIfExists() const;
+    G4String GetNtupleDirectoryNameIfExists() const;
     G4int    GetCompressionLevel() const;
 
     // Methods for handling histograms

--- a/source/analysis/management/include/G4VAnalysisManager.hh
+++ b/source/analysis/management/include/G4VAnalysisManager.hh
@@ -33,6 +33,10 @@
 // are declared as virtual protected.
 
 // Author: Ivana Hrivnacova, 09/07/2013  (ivana@ipno.in2P2.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - added directory getters which detect
+//                              if directory exists
 
 #ifndef G4VAnalysisManager_h
 #define G4VAnalysisManager_h 1

--- a/source/analysis/management/include/G4VFileManager.hh
+++ b/source/analysis/management/include/G4VFileManager.hh
@@ -27,6 +27,10 @@
 // Base class for File manager.
 //
 // Author: Ivana Hrivnacova, 18/06/2013  (ivana@ipno.in2p3.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - added directory getters which detect
+//                              if directory exists
 
 #ifndef G4VFileManager_h
 #define G4VFileManager_h 1

--- a/source/analysis/management/include/G4VFileManager.hh
+++ b/source/analysis/management/include/G4VFileManager.hh
@@ -35,6 +35,10 @@
 #include "G4VTHnFileManager.hh"
 #include "globals.hh"
 
+// check whether directories exist
+#include <sys/types.h>
+#include <sys/stat.h>
+
 namespace tools {
 namespace histo { 
 class h1d; 
@@ -75,6 +79,8 @@ class G4VFileManager : public G4BaseFileManager
     G4bool IsOpenFile() const;
     G4String GetHistoDirectoryName() const;
     G4String GetNtupleDirectoryName() const;
+    G4String GetHistoDirectoryNameIfExists() const;
+    G4String GetNtupleDirectoryNameIfExists() const;
 
     // Access to helpers
     template <typename HT>
@@ -108,6 +114,36 @@ inline G4String G4VFileManager::GetHistoDirectoryName() const
 
 inline G4String G4VFileManager::GetNtupleDirectoryName() const 
 { return fNtupleDirectoryName; }
+
+inline G4String G4VFileManager::GetHistoDirectoryNameIfExists() const 
+{  
+  G4String dirName = fHistoDirectoryName;
+
+  struct stat info;
+
+  int statRC = stat( dirName, &info );
+
+  if (statRC==0 and info.st_mode and S_IFDIR) {
+    return dirName;
+  } else {
+    return "";
+  }
+}
+
+inline G4String G4VFileManager::GetNtupleDirectoryNameIfExists() const
+{
+  G4String dirName = fNtupleDirectoryName;
+
+  struct stat info;
+
+  int statRC = stat( dirName, &info );
+
+  if (statRC==0 and info.st_mode and S_IFDIR) {
+    return dirName;
+  } else {
+    return "";
+  }
+}
 
 template <>
 inline

--- a/source/analysis/management/src/G4VAnalysisManager.cc
+++ b/source/analysis/management/src/G4VAnalysisManager.cc
@@ -25,6 +25,10 @@
 //
 
 // Author: Ivana Hrivnacova, 09/07/2013  (ivana@ipno.in2p3.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - added directory getters which detect
+//                              if directory exists
 
 #include "G4VAnalysisManager.hh"
 #include "G4AnalysisMessenger.hh"

--- a/source/analysis/management/src/G4VAnalysisManager.cc
+++ b/source/analysis/management/src/G4VAnalysisManager.cc
@@ -318,6 +318,18 @@ G4String G4VAnalysisManager::GetNtupleDirectoryName() const
   return fVFileManager->GetNtupleDirectoryName(); 
 }
 
+//
+G4String G4VAnalysisManager::GetHistoDirectoryNameIfExists() const 
+{
+  return fVFileManager->GetHistoDirectoryNameIfExists();
+}
+
+//_____________________________________________________________________________
+G4String G4VAnalysisManager::GetNtupleDirectoryNameIfExists() const
+{
+  return fVFileManager->GetNtupleDirectoryNameIfExists();
+}
+
 //_____________________________________________________________________________
 G4int G4VAnalysisManager::GetCompressionLevel() const
 {

--- a/source/analysis/xml/include/G4XmlAnalysisManager.hh
+++ b/source/analysis/xml/include/G4XmlAnalysisManager.hh
@@ -28,6 +28,9 @@
 // It delegates most of functions to the object specific managers. 
 
 // Author: Ivana Hrivnacova, 18/06/2013  (ivana@ipno.in2p3.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - enabled saving to directories
 
 #ifndef G4XmlAnalysisManager_h
 #define G4XmlAnalysisManager_h 1

--- a/source/analysis/xml/include/G4XmlAnalysisManager.hh
+++ b/source/analysis/xml/include/G4XmlAnalysisManager.hh
@@ -85,8 +85,8 @@ class G4XmlAnalysisManager : public G4ToolsAnalysisManager
     G4bool WriteH3();
     G4bool WriteP1();
     G4bool WriteP2();
-    G4bool WriteNtuple();
-    G4bool CloseNtupleFiles();
+    //G4bool WriteNtuple();
+    //G4bool CloseNtupleFiles();
     G4bool Reset();
 
     // data members
@@ -97,4 +97,3 @@ class G4XmlAnalysisManager : public G4ToolsAnalysisManager
 #include "G4XmlAnalysisManager.icc"
 
 #endif
-

--- a/source/analysis/xml/include/G4XmlAnalysisManager.icc
+++ b/source/analysis/xml/include/G4XmlAnalysisManager.icc
@@ -49,9 +49,13 @@ G4bool G4XmlAnalysisManager::WriteT(const std::vector<T*>& htVector,
     if ( fState.GetVerboseL3() ) 
       fState.GetVerboseL3()->Message("write", hnType, name);
 #endif
-    G4String path = "/";
-    path.append(directoryName);
+    G4String path = "";
+    if (!directoryName.empty()) {
+      path.append(directoryName);
+      path.append("/");
+    }
     std::shared_ptr<std::ofstream> hnFile = fFileManager->GetFile();
+
     // Do nothing if there is no file
     if ( ! hnFile.get() ) return false;
 

--- a/source/analysis/xml/src/G4XmlAnalysisManager.cc
+++ b/source/analysis/xml/src/G4XmlAnalysisManager.cc
@@ -25,6 +25,9 @@
 //
 
 // Author: Ivana Hrivnacova, 18/06/2013  (ivana@ipno.in2p3.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - enabled saving to directories
 
 #include "G4XmlAnalysisManager.hh"
 #include "G4XmlFileManager.hh"
@@ -121,7 +124,7 @@ G4bool G4XmlAnalysisManager::WriteH1()
   auto result = true;
 
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName(); 
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists(); 
     result = WriteT(h1Vector, hnVector, directoryName, "h1");
   }  
   else {
@@ -146,7 +149,7 @@ G4bool G4XmlAnalysisManager::WriteH2()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName(); 
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists(); 
     result = WriteT(h2Vector, hnVector, directoryName, "h2");
   }  
   else {
@@ -171,7 +174,7 @@ G4bool G4XmlAnalysisManager::WriteH3()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName(); 
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists(); 
     result = WriteT(h3Vector, hnVector, directoryName, "h3");
   }  
   else {
@@ -196,7 +199,7 @@ G4bool G4XmlAnalysisManager::WriteP1()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName(); 
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists(); 
     result = WriteT(p1Vector, hnVector, directoryName, "p1");
   }  
   else {
@@ -221,7 +224,7 @@ G4bool G4XmlAnalysisManager::WriteP2()
   auto result = true;
   
   if ( ! G4Threading::IsWorkerThread() )  {
-    auto directoryName = fFileManager->GetHistoDirectoryName(); 
+    auto directoryName = fFileManager->GetHistoDirectoryNameIfExists(); 
     result = WriteT(p2Vector, hnVector, directoryName, "p2");
   }  
   else {

--- a/source/analysis/xml/src/G4XmlFileManager.cc
+++ b/source/analysis/xml/src/G4XmlFileManager.cc
@@ -25,6 +25,9 @@
 //
 
 // Author: Ivana Hrivnacova, 18/06/2013  (ivana@ipno.in2p3.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - enabled saving to directories
 
 #include "G4XmlFileManager.hh"
 #include "G4XmlHnFileManager.hh"

--- a/source/analysis/xml/src/G4XmlFileManager.cc
+++ b/source/analysis/xml/src/G4XmlFileManager.cc
@@ -134,7 +134,7 @@ G4bool G4XmlFileManager::OpenFile(const G4String& fileName)
   if ( fState.GetIsMaster() ) {
     // this seems to only be for histograms but still seems like a hack to assume anything that the master thread saves is a histogram...
     // set description file name so that we can properly save to directories
-    auto path = GetHistoDirectoryName();
+    auto path = GetHistoDirectoryNameIfExists();
     if (!path.empty()) {
       path.append("/");
     }
@@ -160,7 +160,7 @@ G4bool G4XmlFileManager::CreateNtupleFile(
   XmlNtupleDescription* ntupleDescription)
 {
   // set description file name so that we can properly save to directories
-  auto path = GetNtupleDirectoryName();
+  auto path = GetNtupleDirectoryNameIfExists();
   if (!path.empty()) {
       path.append("/");
     }

--- a/source/analysis/xml/src/G4XmlFileManager.cc
+++ b/source/analysis/xml/src/G4XmlFileManager.cc
@@ -132,8 +132,15 @@ G4bool G4XmlFileManager::OpenFile(const G4String& fileName)
 
   // Create histograms file (on master)
   if ( fState.GetIsMaster() ) {
+    // this seems to only be for histograms but still seems like a hack to assume anything that the master thread saves is a histogram...
+    // set description file name so that we can properly save to directories
+    auto path = GetHistoDirectoryName();
+    if (!path.empty()) {
+      path.append("/");
+    }
+
     // Create file (and save in in the file map (on master only)
-    fFile = CreateTFile(name);
+    fFile = CreateTFile(path + name);
     if ( ! fFile) {
       G4ExceptionDescription description;
       description << "Failed to create file " << fileName;
@@ -152,6 +159,14 @@ G4bool G4XmlFileManager::OpenFile(const G4String& fileName)
 G4bool G4XmlFileManager::CreateNtupleFile(
   XmlNtupleDescription* ntupleDescription)
 {
+  // set description file name so that we can properly save to directories
+  auto path = GetNtupleDirectoryName();
+  if (!path.empty()) {
+      path.append("/");
+    }
+  ntupleDescription->fFileName = path+fFileName+"_nt_"
+                                  +ntupleDescription->fNtupleBooking.name();
+
   // get ntuple file name per object (if defined)
   auto ntupleFileName = GetNtupleFileName(ntupleDescription);
 

--- a/source/analysis/xml/src/G4XmlNtupleManager.cc
+++ b/source/analysis/xml/src/G4XmlNtupleManager.cc
@@ -92,8 +92,8 @@ void G4XmlNtupleManager::FinishTNtuple(
   }
 
   // Write header
-  G4String path = "";
-  path.append(fFileManager->GetNtupleDirectoryName());
+  G4String path = "/";
+  path.append(fFileManager->GetNtupleDirectoryNameIfExists());
   ntupleDescription->fNtuple
     ->write_header(path, ntupleDescription->fNtupleBooking.name(), 
                    ntupleDescription->fNtupleBooking.title());  

--- a/source/analysis/xml/src/G4XmlNtupleManager.cc
+++ b/source/analysis/xml/src/G4XmlNtupleManager.cc
@@ -92,7 +92,7 @@ void G4XmlNtupleManager::FinishTNtuple(
   }
 
   // Write header
-  G4String path = "/";
+  G4String path = "";
   path.append(fFileManager->GetNtupleDirectoryName());
   ntupleDescription->fNtuple
     ->write_header(path, ntupleDescription->fNtupleBooking.name(), 

--- a/source/analysis/xml/src/G4XmlNtupleManager.cc
+++ b/source/analysis/xml/src/G4XmlNtupleManager.cc
@@ -25,6 +25,9 @@
 //
 
 // Author: Ivana Hrivnacova, 18/06/2013  (ivana@ipno.in2p3.fr)
+//
+// Edits:
+// Nate MacFadden, 01/11/2021 - enabled saving to directories
 
 #include "G4XmlNtupleManager.hh"
 #include "G4XmlFileManager.hh"


### PR DESCRIPTION
Recommendation to allow the analysis manager methods SetHistoDirectoryName and SetNtupleDirectoryName to work with xml and csv files (currently, they have no effect).

In proposed change, if one of the two aforementioned methods are called (e.g., SetNtupleDirectoryName("exampleDirectory") ) **and** the user is saving as either xml or csv, then Geant4 will attempt to save the associated files in said directory. This is effectively identical to putting a file path in the saved file names. If the user is saving as root, no change occurs. If the user is saving as xml or csv but not using said methods, then the files will be saved as previously.

For user safety, these changes are unable to create/modify directory structure. Thus, if a user requests files to be saved in a directory that does **not** exist, then no files will be saved.