### PR TITLE
Add missing links in geant4-config script

### DIFF
--- a/cmake/Templates/geant4-config.in
+++ b/cmake/Templates/geant4-config.in
@@ -131,6 +131,7 @@ libs="-lG4interfaces \
 -lG4intercoms \
 -lG4global \
 -lG4tools \
+-lG4tasking \
 @G4_LINK_CXX_FILESYSTEM@"
 
 #-----------------------------------------------------------------------

--- a/cmake/Templates/geant4-config.in
+++ b/cmake/Templates/geant4-config.in
@@ -175,6 +175,14 @@ if test "x${have_gdml}" = "xyes" ; then
   cflags="${cflags} @G4_XERCESC_CFLAGS@"
 fi
 
+# - PTL
+have_ptl="@G4_BUILTWITH_PTL@"
+feature_list="${feature_list} ptl[${have_ptl}]"
+
+if test "x${have_ptl}" = "xyes" ; then
+  libs="${libs} -lG4ptl"
+fi
+
 # - USolids
 have_usolids="@G4_BUILTWITH_USOLIDS@"
 feature_list="${feature_list} usolids[${have_usolids}]"


### PR DESCRIPTION
This PR adds the missing links of PTL and G4tasking libraries in the geant4-config script