### PR TITLE
Fix for bugzilla problem 2314

### DIFF
--- a/source/geometry/navigation/src/G4RegularNavigation.cc
+++ b/source/geometry/navigation/src/G4RegularNavigation.cc
@@ -282,7 +282,10 @@ G4double G4RegularNavigation::ComputeStepSkippingEqualMaterials(
 		    message);
       }
     }
-    
+    else{
+      // reset the zero step counter when a non-zero step was performed
+      fNumberZeroSteps = 0;
+    }
     if( (bFirstStep) && (newStep < currentProposedStepLength) )
     {
       exiting  = true;

--- a/source/geometry/navigation/src/G4RegularNavigation.cc
+++ b/source/geometry/navigation/src/G4RegularNavigation.cc
@@ -205,16 +205,16 @@ G4double G4RegularNavigation::ComputeStepSkippingEqualMaterials(
                                    .InverseTransformPoint(localPoint);
       std::ostringstream message;
       message << "G4RegularNavigation::ComputeStepSkippingEqualMaterials()"
-	      << "Stuck Track: potential geometry or navigation problem."
-	      << G4endl
-	      << "        Track stuck, moving for more than " 
-	      << ii << " steps" << G4endl
-	      << "- at point " << pGlobalpoint << G4endl
-	      << "        local direction: " << localDirection << G4endl;
+        << "Stuck Track: potential geometry or navigation problem."
+        << G4endl
+        << "        Track stuck, moving for more than " 
+        << ii << " steps" << G4endl
+        << "- at point " << pGlobalpoint << G4endl
+        << "        local direction: " << localDirection << G4endl;
       G4Exception("G4RegularNavigation::ComputeStepSkippingEqualMaterials()",
-		  "GeomRegNav1001",
-		  EventMustBeAborted,
-		  message);
+      "GeomRegNav1001",
+      EventMustBeAborted,
+      message);
     }
     newStep = voxelBox->DistanceToOut( localPoint, localDirection );
     fLastStepWasZero = (newStep<fMinStep);
@@ -226,63 +226,64 @@ G4double G4RegularNavigation::ComputeStepSkippingEqualMaterials(
       {
         G4ThreeVector pGlobalpoint = history.GetTransform(ide)
                                      .InverseTransformPoint(localPoint);
-	std::ostringstream message;
-	message.precision(16);
-	message << "G4RegularNavigation::ComputeStepSkippingEqualMaterials(): another 'zero' step, # "
-	       << fNumberZeroSteps
-	       << ", at " << pGlobalpoint
-	       << ", nav-comp-step calls # " << ii
-	       << ", Step= " << newStep;
-        G4Exception("G4RegularNavigation::ComputeStepSkippingEqualMaterials()",
-                    "GeomRegNav1002", JustWarning, message,
-                    "Potential overlap in geometry!");
+      std::ostringstream message;
+      message.precision(16);
+      message << "G4RegularNavigation::ComputeStepSkippingEqualMaterials(): another 'zero' step, # "
+            << fNumberZeroSteps
+            << ", at " << pGlobalpoint
+            << ", nav-comp-step calls # " << ii
+            << ", Step= " << newStep;
+            G4Exception("G4RegularNavigation::ComputeStepSkippingEqualMaterials()",
+                        "GeomRegNav1002", JustWarning, message,
+                        "Potential overlap in geometry!");
       }
 #endif
       if( fNumberZeroSteps > fActionThreshold_NoZeroSteps-1 )
       {
-	// Act to recover this stuck track. Pushing it along direction
-	//
-	newStep = std::min(101*kCarTolerance*std::pow(10,fNumberZeroSteps-2),0.1);
+        // Act to recover this stuck track. Pushing it along direction
+        //
+        newStep = std::min(101*kCarTolerance*std::pow(10,fNumberZeroSteps-2),0.1);
 #ifdef G4DEBUG_NAVIGATION
         G4ThreeVector pGlobalpoint = history.GetTransform(ide)
                                        .InverseTransformPoint(localPoint);
-	std::ostringstream message;
-	message.precision(16);
-	message << "Track stuck or not moving." << G4endl
-                << "          Track stuck, not moving for " 
-                << fNumberZeroSteps << " steps" << G4endl
-                << "- at point " << pGlobalpoint
-                << " (local point " << localPoint << ")" << G4endl
-                << "        local direction: " << localDirection 
-                << "          Potential geometry or navigation problem !"
-                << G4endl
-                << "          Trying pushing it of " << newStep << " mm ...";
-        G4Exception("G4RegularNavigation::ComputeStepSkippingEqualMaterials()",
-                    "GeomRegNav1003", JustWarning, message,
-                    "Potential overlap in geometry!");
+        std::ostringstream message;
+        message.precision(16);
+        message << "Track stuck or not moving." << G4endl
+                      << "          Track stuck, not moving for " 
+                      << fNumberZeroSteps << " steps" << G4endl
+                      << "- at point " << pGlobalpoint
+                      << " (local point " << localPoint << ")" << G4endl
+                      << "        local direction: " << localDirection 
+                      << "          Potential geometry or navigation problem !"
+                      << G4endl
+                      << "          Trying pushing it of " << newStep << " mm ...";
+              G4Exception("G4RegularNavigation::ComputeStepSkippingEqualMaterials()",
+                          "GeomRegNav1003", JustWarning, message,
+                          "Potential overlap in geometry!");
 #endif
       }
       if( fNumberZeroSteps > fAbandonThreshold_NoZeroSteps-1 )
       {
-	// Must kill this stuck track
-	//
-	G4ThreeVector pGlobalpoint = history.GetTransform(ide)
-                                     .InverseTransformPoint(localPoint);
-	std::ostringstream message;
-	message << "G4RegularNavigation::ComputeStepSkippingEqualMaterials()"
-		<< "Stuck Track: potential geometry or navigation problem."
-		<< G4endl
-		<< "        Track stuck, not moving for " 
-		<< fNumberZeroSteps << " steps" << G4endl
-		<< "- at point " << pGlobalpoint << G4endl	
-		<< "        local direction: " << localDirection << G4endl;
-	G4Exception("G4RegularNavigation::ComputeStepSkippingEqualMaterials()",
-		    "GeomRegNav1004",
-		    EventMustBeAborted,
-		    message);
+        // Must kill this stuck track
+        //
+        G4ThreeVector pGlobalpoint = history.GetTransform(ide)
+                                          .InverseTransformPoint(localPoint);
+        std::ostringstream message;
+        message << "G4RegularNavigation::ComputeStepSkippingEqualMaterials()"
+          << "Stuck Track: potential geometry or navigation problem."
+          << G4endl
+          << "        Track stuck, not moving for " 
+          << fNumberZeroSteps << " steps" << G4endl
+          << "- at point " << pGlobalpoint << G4endl	
+          << "        local direction: " << localDirection << G4endl;
+        G4Exception("G4RegularNavigation::ComputeStepSkippingEqualMaterials()",
+              "GeomRegNav1004",
+              EventMustBeAborted,
+              message);
       }
     }
-    else{
+    else
+    {
       // reset the zero step counter when a non-zero step was performed
       fNumberZeroSteps = 0;
     }


### PR DESCRIPTION
The [bugzilla problem 2314](https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2314) is still present despite the changes up to version 11.0.0, raising a GeomRegNav1004 exception:
```
-------- EEEE ------- G4Exception-START -------- EEEE -------
*** G4Exception : GeomRegNav1004
      issued by : G4RegularNavigation::ComputeStepSkippingEqualMaterials()
G4RegularNavigation::ComputeStepSkippingEqualMaterials()Stuck Track: potential geometry or navigation problem.
        Track stuck, not moving for 25 steps
- at point (0.136942,-0.11583,-4.28004)
        local direction: (-0.478457,-0.719124,-0.503924)

*** Event Must Be Aborted ***
G4Track (0x7fdea7db9960) - track ID = 1, parent ID = 0
 Particle type : gamma - creator process : not available
 Kinetic energy : 100 keV - Momentum direction : (-0,-0,1)
 Step length : 3.42088 mm  - total energy deposit : 0 eV 
 Pre-step point : (-0.0696549,0.234524,-4.54232) - Physical volume : Target (tm2)
 - defined by : Transportation - step status : 1
 Post-step point : (-0.0696549,0.234524,-4.54232) - Physical volume : Target (tm2)
 - defined by : compt - step status : 7
 *** Note: Step information might not be properly updated.

-------- EEEE -------- G4Exception-END --------- EEEE -------

```
It happens quite frequently to have a single zero step at voxel edges, so for voxel data with large regions containing the same material the threshold for killing the track can be reached.
As i mentioned in comment 3 in the bugzilla issue, the zero-step counter has to be reset when a non-zero step has been performed to prevent this from happening.

I have also fixed the mixed indentation and converted the tabs to spaces in the G4RegularNavigation.cc