### PR TITLE
Optical tags added to text geometry

### DIFF
--- a/examples/extended/optical/OpNovice/OpNovice.cc
+++ b/examples/extended/optical/OpNovice/OpNovice.cc
@@ -43,6 +43,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 #include "OpNoviceDetectorConstruction.hh"
+#include "OpNoviceTGDetectorConstruction.hh"
 #ifdef GEANT4_USE_GDML
 #  include "OpNoviceGDMLDetectorConstruction.hh"
 #endif
@@ -63,11 +64,11 @@ namespace
   {
     G4cerr << " Usage: " << G4endl;
 #ifdef GEANT4_USE_GDML
-    G4cerr << " OpNovice [-g gdmlfile] [-m macro ] [-u UIsession] [-t "
+    G4cerr << " OpNovice [-gdml gdmlfile] [-tg tgfile] [-m macro ] [-u UIsession] [-t "
               "nThreads] [-r seed] "
            << G4endl;
 #else
-    G4cerr << " OpNovice  [-m macro ] [-u UIsession] [-t nThreads] [-r seed] "
+    G4cerr << " OpNovice  [-m macro ] [-tg tgfile] [-u UIsession] [-t nThreads] [-r seed] "
            << G4endl;
 #endif
     G4cerr << "   note: -t option is available only for multi-threaded mode."
@@ -87,6 +88,7 @@ int main(int argc, char** argv)
     return 1;
   }
   G4String gdmlfile = "";
+  G4String tgfile = "";
   G4String macro;
   G4String session;
 #ifdef G4MULTITHREADED
@@ -96,8 +98,10 @@ int main(int argc, char** argv)
   G4long myseed = 345354;
   for(G4int i = 1; i < argc; i = i + 2)
   {
-    if(G4String(argv[i]) == "-g")
+    if(G4String(argv[i]) == "-gdml")
       gdmlfile = argv[i + 1];
+    else if(G4String(argv[i]) == "-tg")
+      tgfile = argv[i + 1];
     else if(G4String(argv[i]) == "-m")
       macro = argv[i + 1];
     else if(G4String(argv[i]) == "-u")
@@ -147,6 +151,10 @@ int main(int argc, char** argv)
            << "built with gdml support." << G4endl;
     return 1;
 #endif
+  }
+  else if (tgfile != "")
+  {
+    runManager->SetUserInitialization(new OpNoviceTGDetectorConstruction(tgfile));
   }
   else
   {

--- a/examples/extended/optical/OpNovice/README
+++ b/examples/extended/optical/OpNovice/README
@@ -85,7 +85,7 @@ Visualisation
 
    This example handles the program arguments in a new way.
    It can be run with the following optional optionaarguments:
-   $ OpNovice [-g gdmlfile] [-m macro ] [-u UIsession] [-t nThreads]
+   $ OpNovice [-gdml gdmlfile] [-tg tgfile] [-m macro ] [-u UIsession] [-t nThreads]
 
    The -t option is available only in multi-threading mode
    and it allows the user to override the Geant4 default number of
@@ -97,7 +97,11 @@ Visualisation
 
  - execute OpNovice in 'batch' mode from macro files using a gdml file
    to define the geometry
- 	$ OpNovice -g NoviceExample.gdml -m OpNovice.in
+ 	$ OpNovice -gdml ../gdml/NoviceExample.gdml -m OpNovice.in
+ 
+ - execute OpNovice in 'batch' mode from macro files using a tg file
+   to define the geometry
+    $ OpNovice -tg ../tg/NoviceExample.tg -m OpNovice.in
 	
  - execute OpNovice in 'interactive mode' with visualization
  	$ OpNovice
@@ -121,4 +125,9 @@ Macros
 gdml files
 ----------
 NoviceExample.gdml: example gdml file corresponding to
+OpNoviceDetectorConstruction
+
+textgeom files
+----------
+NoviceExample.tg: example textgeom file corresponding to
 OpNoviceDetectorConstruction

--- a/examples/extended/optical/OpNovice/include/OpNoviceTGDetectorConstruction.hh
+++ b/examples/extended/optical/OpNovice/include/OpNoviceTGDetectorConstruction.hh
@@ -1,0 +1,64 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+#ifndef OpNoviceTGDetectorConstruction_h
+#define OpNoviceTGDetectorConstruction_h 1
+
+#include "globals.hh"
+#include "G4VUserDetectorConstruction.hh"
+#include "OpNoviceDetectorMessenger.hh"
+
+// class G4tgrMessenger;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class OpNoviceTGDetectorConstruction : public G4VUserDetectorConstruction
+{
+ public:
+  OpNoviceTGDetectorConstruction(G4String fname);
+  virtual ~OpNoviceTGDetectorConstruction();
+
+  virtual G4VPhysicalVolume* Construct();
+  virtual void ConstructSDandField();
+  void UpdateGeometry();
+  void SetDumpGdml(G4bool);
+  G4bool IsDumpGdml() const;
+  void SetVerbose(G4bool fverbose);
+  G4bool IsVerbose() const;
+  void SetDumpGdmlFile(G4String fDumpGdmlFileName);
+  G4String GetDumpGdmlFileName() const;
+
+ private:
+  OpNoviceTGDetectorConstruction& operator=(
+    const OpNoviceTGDetectorConstruction& right);
+  OpNoviceDetectorMessenger* fDetectorMessenger;
+
+  G4String fTGFile;
+  G4String fDumpGdmlFileName;
+  G4bool fVerbose;
+  G4bool fDumpGdml;
+};
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo.....
+#endif

--- a/examples/extended/optical/OpNovice/src/OpNoviceDetectorMessenger.cc
+++ b/examples/extended/optical/OpNovice/src/OpNoviceDetectorMessenger.cc
@@ -27,6 +27,7 @@
 #include "OpNoviceDetectorMessenger.hh"
 #include "OpNoviceDetectorConstruction.hh"
 #include "OpNoviceGDMLDetectorConstruction.hh"
+#include "OpNoviceTGDetectorConstruction.hh"
 #include "G4UIdirectory.hh"
 #include "G4UIcmdWithABool.hh"
 #include "G4UIcmdWithAString.hh"
@@ -87,16 +88,27 @@ void OpNoviceDetectorMessenger::SetNewValue(G4UIcommand* command,
     if(command == fDumpGdmlFileNameCmd)
       dc1->SetDumpGdmlFile(newValue);
   }
-  else
+  OpNoviceGDMLDetectorConstruction* dc2 =
+    dynamic_cast<OpNoviceGDMLDetectorConstruction*>(fOpNoviceDetCon);
+  if(dc2 != nullptr)
   {
-    OpNoviceGDMLDetectorConstruction* dc2 =
-      dynamic_cast<OpNoviceGDMLDetectorConstruction*>(fOpNoviceDetCon);
     if(command == fVerboseCmd)
       dc2->SetVerbose(fVerboseCmd->GetNewBoolValue(newValue));
     if(command == fDumpGdmlCmd)
       dc2->SetDumpGdml(fDumpGdmlCmd->GetNewBoolValue(newValue));
     if(command == fDumpGdmlFileNameCmd)
       dc2->SetDumpGdmlFile(newValue);
+  }
+  OpNoviceTGDetectorConstruction* dc3 =
+    dynamic_cast<OpNoviceTGDetectorConstruction*>(fOpNoviceDetCon);
+  if(dc3 != nullptr)
+  {
+    if(command == fVerboseCmd)
+      dc3->SetVerbose(fVerboseCmd->GetNewBoolValue(newValue));
+    if(command == fDumpGdmlCmd)
+      dc3->SetDumpGdml(fDumpGdmlCmd->GetNewBoolValue(newValue));
+    if(command == fDumpGdmlFileNameCmd)
+      dc3->SetDumpGdmlFile(newValue);
   }
 }
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/examples/extended/optical/OpNovice/src/OpNoviceTGDetectorConstruction.cc
+++ b/examples/extended/optical/OpNovice/src/OpNoviceTGDetectorConstruction.cc
@@ -1,0 +1,130 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+
+#include "OpNoviceTGDetectorConstruction.hh"
+
+#include "G4LogicalVolumeStore.hh"
+#include "G4PhysicalVolumeStore.hh"
+#include "G4RunManager.hh"
+#include "G4tgbVolumeMgr.hh"
+#include "G4GDMLParser.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+OpNoviceTGDetectorConstruction::OpNoviceTGDetectorConstruction(
+  G4String fname)
+  : G4VUserDetectorConstruction()
+{
+  fDumpGdmlFileName = "OpNovice_dump.gdml";
+  fVerbose        = false;
+  fDumpGdml       = false;
+  fTGFile         = fname;
+  // create a messenger for this class
+  fDetectorMessenger = new OpNoviceDetectorMessenger(this);
+
+  G4cout << "Building detector from TG file: " << fname << G4endl << G4endl;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+OpNoviceTGDetectorConstruction::~OpNoviceTGDetectorConstruction()
+{
+  delete fDetectorMessenger;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+G4VPhysicalVolume* OpNoviceTGDetectorConstruction::Construct()
+{
+  G4tgbVolumeMgr* volmgr = G4tgbVolumeMgr::GetInstance();
+  volmgr->AddTextFile(fTGFile);
+
+  G4VPhysicalVolume* physiWorld = volmgr->ReadAndConstructDetector();
+
+  if(fDumpGdml)
+  {
+    G4GDMLParser* parser = new G4GDMLParser();
+    parser->Write(fDumpGdmlFileName, physiWorld);
+  }
+
+  if(fVerbose)
+  {
+    G4cout << "Found world:  " << physiWorld->GetName() << G4endl;
+    G4cout << "world LV:  " << physiWorld->GetLogicalVolume()->GetName() << G4endl;
+  }
+  G4LogicalVolumeStore* pLVStore = G4LogicalVolumeStore::GetInstance();
+  if(fVerbose)
+  {
+    G4cout << "Found " << pLVStore->size() << " logical volumes." << G4endl
+           << G4endl;
+  }
+  G4PhysicalVolumeStore* pPVStore = G4PhysicalVolumeStore::GetInstance();
+  if(fVerbose)
+  {
+    G4cout << "Found " << pPVStore->size() << " physical volumes." << G4endl
+           << G4endl;
+  }
+  return physiWorld;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+void OpNoviceTGDetectorConstruction::ConstructSDandField() {}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+void OpNoviceTGDetectorConstruction::UpdateGeometry()
+{
+  G4RunManager::GetRunManager()->DefineWorldVolume(Construct());
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+void OpNoviceTGDetectorConstruction::SetDumpGdml(G4bool val)
+{
+  fDumpGdml = val;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+G4bool OpNoviceTGDetectorConstruction::IsDumpGdml() const
+{
+  return fDumpGdml;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+void OpNoviceTGDetectorConstruction::SetVerbose(G4bool val)
+{
+  fVerbose = val;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+G4bool OpNoviceTGDetectorConstruction::IsVerbose() const { return fVerbose; }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+void OpNoviceTGDetectorConstruction::SetDumpGdmlFile(G4String val)
+{
+  fDumpGdmlFileName = val;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+G4String OpNoviceTGDetectorConstruction::GetDumpGdmlFileName() const
+{
+  return fDumpGdmlFileName;
+}

--- a/examples/extended/optical/OpNovice/textgeom/NoviceExample.tg
+++ b/examples/extended/optical/OpNovice/textgeom/NoviceExample.tg
@@ -1,0 +1,65 @@
+:rotm r000 0  0  0
+
+// Optical properties can be added to both defined and built-in(G4_xxx) materials.
+:isot N14 7 14 14.0031
+:isot N15 7 15 15.0001
+:elem_from_isot nitrogen N 2 N14 0.99632 N15 0.00368
+
+:isot O16 8 16 15.9949
+:isot O17 8 17 16.9991
+:isot O18 8 18 17.9992
+:elem_from_isot oxygen O 3 O16 0.99757 O17 0.00038 O18 0.00205
+
+:isot H1 1 1 1.00782503081372
+:isot H2 1 2 2.01410199966617
+:elem_from_isot hydrogen H 2 H1 0.999885 H2 0.000115
+
+:mixt_by_weight air  1.29 2 nitrogen 0.7 oxygen 0.3
+:mixt_by_natoms water 1.0 2 hydrogen 2   oxygen 1
+
+:volu world   BOX  15*m  15*m  15*m air   // G4_AIR
+:volu expHall BOX  10*m  10*m  10*m air   // G4_AIR
+:volu tank    BOX   5*m   5*m   5*m water // G4_WATER
+:volu bubble  BOX 0.5*m 0.5*m 0.5*m air   // G4_AIR
+
+:place expHall 1 world r000 0 0     0
+:place tank    2 world r000 0 0     0
+:place bubble  3 world r000 0 2.5*m 0
+
+// optical properties of water
+:prop water // G4_WATER
+  SCINTILLATIONYIELD 50./MeV
+  RESOLUTIONSCALE 1.
+  SCINTILLATIONTIMECONSTANT1 1.*ns
+  SCINTILLATIONTIMECONSTANT2 10*ns
+  SCINTILLATIONYIELD1 0.8
+  SCINTILLATIONYIELD2 0.2
+  MIEHG_FORWARD  0.99
+  MIEHG_BACKWARD 0.99
+  MIEHG_FORWARD_RATIO 0.8
+  photon_energies 32 2.034*eV 2.068*eV 2.103*eV 2.139*eV 2.177*eV 2.216*eV 2.256*eV 2.298*eV 2.341*eV 2.386*eV 2.433*eV 2.481*eV 2.532*eV 2.585*eV 2.640*eV 2.697*eV 2.757*eV 2.820*eV 2.885*eV 2.954*eV 3.026*eV 3.102*eV 3.181*eV 3.265*eV 3.353*eV 3.446*eV 3.545*eV 3.649*eV 3.760*eV 3.877*eV   4.002*eV 4.136*eV
+  SCINTILLATIONCOMPONENT1 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.
+  SCINTILLATIONCOMPONENT2 0.01 1. 2. 3. 4. 5. 6. 7. 8. 9. 8. 7. 6. 4. 3. 2. 1. 0.01 1. 2. 3. 4. 5. 6. 7. 8. 9. 8. 7. 6. 5. 4.
+  RINDEX 1.3435 1.344 1.3445 1.345 1.3455 1.346 1.3465 1.347 1.3475 1.348 1.3485 1.3492 1.35 1.3505 1.351 1.3518 1.3522 1.3530 1.3535 1.354 1.3545 1.355 1.3555 1.356 1.3568 1.3572 1.358 1.3585 1.359 1.3595 1.36 1.3608
+  ABSLENGTH 3.448*m  4.082*m  6.329*m  9.174*m  12.346*m 13.889*m 15.152*m 17.241*m 18.868*m 20.000*m 26.316*m 35.714*m 45.455*m 47.619*m 52.632*m 52.632*m 55.556*m 52.632*m 52.632*m 47.619*m 45.455*m 41.667*m 37.037*m 33.333*m 30.000*m 28.500*m 27.000*m 24.500*m 22.000*m 19.500*m 17.500*m 14.500*m
+  photon_energies 60 1.56962*eV 1.58974*eV 1.61039*eV 1.63157*eV 1.65333*eV 1.67567*eV 1.69863*eV 1.72222*eV 1.74647*eV 1.77142*eV 1.7971*eV  1.82352*eV 1.85074*eV 1.87878*eV 1.90769*eV 1.93749*eV 1.96825*eV 1.99999*eV 2.03278*eV 2.06666*eV 2.10169*eV 2.13793*eV 2.17543*eV 2.21428*eV 2.25454*eV 2.29629*eV 2.33962*eV 2.38461*eV 2.43137*eV 2.47999*eV 2.53061*eV 2.58333*eV 2.63829*eV 2.69565*eV 2.75555*eV 2.81817*eV 2.88371*eV 2.95237*eV 3.02438*eV 3.09999*eV 3.17948*eV 3.26315*eV 3.35134*eV 3.44444*eV 3.54285*eV 3.64705*eV 3.75757*eV 3.87499*eV 3.99999*eV 4.13332*eV 4.27585*eV 4.42856*eV 4.59258*eV 4.76922*eV 4.95999*eV 5.16665*eV 5.39129*eV 5.63635*eV 5.90475*eV 6.19998*eV
+  MIEHG 167024.4*m 158726.7*m 150742*m   143062.5*m 135680.2*m 128587.4*m 121776.3*m 115239.5*m 108969.5*m 102958.8*m 97200.35*m 91686.86*m 86411.33*m 81366.79*m 76546.42*m 71943.46*m 67551.29*m 63363.36*m 59373.25*m 55574.61*m 51961.24*m 48527.00*m 45265.87*m 42171.94*m 39239.39*m 36462.50*m 33835.68*m 31353.41*m 29010.30*m 26801.03*m 24720.42*m 22763.36*m 20924.88*m 19200.07*m 17584.16*m 16072.45*m 14660.38*m 13343.46*m 12117.33*m 10977.70*m 9920.416*m 8941.407*m 8036.711*m 7202.470*m 6434.927*m 5730.429*m 5085.425*m 4496.467*m 3960.210*m 3473.413*m 3032.937*m 2635.746*m 2278.907*m 1959.588*m 1675.064*m 1422.710*m 1200.004*m 1004.528*m 833.9666*m 686.1063*m
+
+// optical properties of air
+:prop air // G4_AIR
+  photon_energies 32 2.034*eV 2.068*eV 2.103*eV 2.139*eV 2.177*eV 2.216*eV 2.256*eV 2.298*eV 2.341*eV 2.386*eV 2.433*eV 2.481*eV 2.532*eV 2.585*eV 2.640*eV 2.697*eV 2.757*eV 2.820*eV 2.885*eV 2.954*eV 3.026*eV 3.102*eV 3.181*eV 3.265*eV 3.353*eV 3.446*eV 3.545*eV 3.649*eV 3.760*eV 3.877*eV   4.002*eV 4.136*eV
+  rindex 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0 1.0
+
+// optical surface between tank and expHall
+:surf tank2expHall tank:2 expHall:1
+  type dielectric_LUTDAVIS
+  model DAVIS
+  finish Rough_LUT
+
+// optical around the bubble
+  :surf aroudBubble skin bubble
+    type dielectric_dielectric
+    model glisur
+    finish polished
+    property photon_energies 2 0.3*eV 0.5*eV
+             reflectivity    0.8    1.0

--- a/source/persistency/ascii/include/G4tgbBorderSurface.hh
+++ b/source/persistency/ascii/include/G4tgbBorderSurface.hh
@@ -1,0 +1,66 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// G4tgbBorderSurface
+//
+// Class description:
+//
+// Transient class of a optical surface; 
+// builds a G4tgbBorderSurface.
+//
+#ifndef G4tgbBorderSurface_hh
+#define G4tgbBorderSurface_hh 1
+
+#include <vector>
+#include <string>
+
+#include "globals.hh"
+#include "G4tgrBorderSurface.hh"
+#include "G4tgbVolumeMgr.hh"
+
+class G4tgbBorderSurface
+{
+  public:
+
+    G4tgbBorderSurface(G4tgrBorderSurface*);
+    ~G4tgbBorderSurface();
+
+    G4String GetName() const { return theName; }
+
+    // Builds a G4BorderSurface or a G4SkinBorderSurface
+    void BuildG4BorderSurface();
+    void BuildG4SkinBorderSurface();
+    void BuildG4LogicalBorderSurface();
+
+  private:
+
+    G4String theName;
+    G4tgrBorderSurface* theTgrBorderSurface = nullptr;
+    G4tgbVolumeMgr* fTgbVolmgr = G4tgbVolumeMgr::GetInstance();
+    G4OpticalSurface *fOptic;
+};
+
+#endif
+

--- a/source/persistency/ascii/include/G4tgbGeometryDumper.hh
+++ b/source/persistency/ascii/include/G4tgbGeometryDumper.hh
@@ -40,6 +40,9 @@
 
 #include "globals.hh"
 #include "G4RotationMatrix.hh"
+#include "G4LogicalBorderSurface.hh"
+#include "G4MaterialPropertiesTable.hh"
+#include "G4LogicalSkinSurface.hh"
 
 class G4Material;
 class G4Element;
@@ -69,6 +72,8 @@ class G4tgbGeometryDumper
     G4String DumpMaterial(G4Material* mat);
     void DumpElement(G4Element* ele);
     void DumpIsotope(G4Isotope* ele);
+    void DumpLogicalBorderSurface(G4LogicalBorderSurface* surf);
+    void DumpLogicalSkinSurface(G4LogicalSkinSurface* skin);
     G4String DumpSolid(G4VSolid* solid, const G4String& extraName = "");
     void DumpBooleanVolume(const G4String& solidType, G4VSolid* so);
     void DumpMultiUnionVolume(  G4VSolid* so);
@@ -109,6 +114,8 @@ class G4tgbGeometryDumper
     std::map<G4String, G4Material*> theMaterials;
     std::map<G4String, G4Element*> theElements;
     std::map<G4String, G4Isotope*> theIsotopes;
+    std::map<G4String, G4LogicalBorderSurface*> theLogicalBorderSurfaces;
+    std::map<G4String, G4LogicalSkinSurface*> theLogicalSkinSurfaces;
     std::map<G4String, G4VSolid*> theSolids;
     std::map<G4String, G4LogicalVolume*> theLogVols;
     std::map<G4String, G4VPhysicalVolume*> thePhysVols;

--- a/source/persistency/ascii/include/G4tgbMaterialMgr.hh
+++ b/source/persistency/ascii/include/G4tgbMaterialMgr.hh
@@ -40,11 +40,14 @@
 #include "G4tgbIsotope.hh"
 #include "G4tgbElement.hh"
 #include "G4tgbMaterial.hh"
+#include "G4tgbMaterialPropertiesTable.hh"
+#include "G4tgbBorderSurface.hh"
 
 #include "G4tgrIsotope.hh"
 #include "G4tgrElement.hh"
-#include "G4tgrElement.hh"
 #include "G4tgrMaterial.hh"
+#include "G4tgrMaterialPropertiesTable.hh"
+#include "G4tgrBorderSurface.hh"
 
 #include "G4Isotope.hh"
 #include "G4Element.hh"
@@ -53,6 +56,8 @@
 using G4mstgbisot = std::map<G4String, G4tgbIsotope*>;
 using G4mstgbelem = std::map<G4String, G4tgbElement*>;
 using G4mstgbmate = std::map<G4String, G4tgbMaterial*>;
+using G4mstgbprop = std::map<G4String, G4tgbMaterialPropertiesTable*>;
+using G4mstgbbrdr = std::map<G4String, G4tgbBorderSurface*>;
 using G4msg4isot = std::map<G4String, G4Isotope*>;
 using G4msg4elem = std::map<G4String, G4Element*>;
 using G4msg4mate = std::map<G4String, G4Material*>;
@@ -72,6 +77,10 @@ class G4tgbMaterialMgr
       // Copy the G4tgrElements into G4tgbElements
     void CopyMaterials();
       // Copy the G4tgrMaterials into G4tgbMaterials
+    void CopyMaterialPropertiesTable();
+      // Copy the G4tgrMaterialPropertiesTable into G4tgbMaterialPropertiesTable
+    void CopyBorderSurface();
+      // Copy the G4tgrBorderSurface into G4tgbBorderSurface
 
     G4Isotope* FindOrBuildG4Isotope(const G4String& name);
       // Look for a G4Isotope that has to exists
@@ -101,10 +110,19 @@ class G4tgbMaterialMgr
     G4tgbMaterial* FindG4tgbMaterial(const G4String& name,
                                      G4bool bMustExist = false) const;
       // Look for a G4tgbMaterial and if not found return nullptr
+    G4tgbMaterialPropertiesTable* FindG4tgbMaterialPropertiesTable(
+      const G4String& name) const;
+      // Look for a G4tgbMaterialPropertiesTable and if not found return nullptr
+    G4tgbBorderSurface* FindG4tgbBorderSurface(const G4String& name) const;
+      // Look for a G4tgbBorderSurface and if not found return nullptr
 
     const G4msg4isot GetG4IsotopeList() const { return theG4Isotopes; }
     const G4msg4elem GetG4ElementList() const { return theG4Elements; }
     const G4msg4mate GetG4MaterialList() const { return theG4Materials; }
+    const G4mstgbprop GetG4MaterialPropertiesTableList() const { 
+      return theG4tgbMaterialPropertiesTables; }
+    const G4mstgbbrdr GetG4tgbBorderSurfaceList() const { 
+      return theG4tgbBorderSurfaces; }
 
   private:
 
@@ -127,6 +145,10 @@ class G4tgbMaterialMgr
       // Container of all G4Elements created
     G4msg4mate theG4Materials;
       // Container of all G4Materials created
+    G4mstgbprop theG4tgbMaterialPropertiesTables;
+      // Container of all G4MaterialPropertyTables created
+    G4mstgbbrdr theG4tgbBorderSurfaces;
+      // Container of all G4MaterialPropertyTables created
 };
 
 #endif

--- a/source/persistency/ascii/include/G4tgbMaterialPropertiesTable.hh
+++ b/source/persistency/ascii/include/G4tgbMaterialPropertiesTable.hh
@@ -1,0 +1,62 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// G4tgbMaterialPropertiesTable
+//
+// Class description:
+//
+// Transient class of a material property table; 
+// builds a G4tgbMaterialPropertiesTable.
+//
+#ifndef G4tgbMaterialPropertiesTable_hh
+#define G4tgbMaterialPropertiesTable_hh 1
+
+#include <vector>
+#include <string>
+
+#include "globals.hh"
+#include "G4tgrMaterialPropertiesTable.hh"
+#include "G4MaterialPropertiesTable.hh"
+
+class G4tgbMaterialPropertiesTable
+{
+  public:
+
+    G4tgbMaterialPropertiesTable(G4tgrMaterialPropertiesTable*);
+    ~G4tgbMaterialPropertiesTable();
+
+    G4String GetName() const { return theName; }
+    G4MaterialPropertiesTable* BuildG4MaterialPropertiesTable();
+      // Build a G4MaterialPropertiesTable
+
+  private:
+
+    G4String theName;
+    G4tgrMaterialPropertiesTable* theTgrTable = nullptr;
+    G4MaterialPropertiesTable* theTable = new G4MaterialPropertiesTable();
+};
+
+#endif
+

--- a/source/persistency/ascii/include/G4tgrBorderSurface.hh
+++ b/source/persistency/ascii/include/G4tgrBorderSurface.hh
@@ -1,0 +1,75 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// G4tgrBorderSurface
+//
+// Class description:
+// G4tgrBorderSurface is a class to register optical surface
+// properties.
+//
+#ifndef G4tgrBorderSurface_hh
+#define G4tgrBorderSurface_hh 1
+
+#include "globals.hh"
+#include "G4tgrMaterialPropertiesTable.hh"
+#include "G4OpticalSurface.hh"
+
+class G4tgrBorderSurface
+{
+  public:
+
+    G4tgrBorderSurface(const std::vector<G4String>&);
+    virtual ~G4tgrBorderSurface();
+
+    G4String GetName() const { return theName; }
+    G4String GetV1Name() const { return V1Name; }
+    G4String GetV2Name() const { return V2Name; }
+    G4int    GetCopyNo1() const { return copyNo1; }
+    G4int    GetCopyNo2() const { return copyNo2; }
+    G4OpticalSurface* GetOptic() const { return theOptic; }
+    G4tgrMaterialPropertiesTable* 
+      GetTgrMaterialPropertiesTable() const { return theMPT; }
+
+    // Converts string to enum.
+    G4SurfaceType          GetType(G4String);
+    G4OpticalSurfaceFinish GetFinish(G4String);
+    G4OpticalSurfaceModel  GetModel(G4String);
+
+  protected:
+
+    G4String theName; /// Name of surface
+    G4String V1Name;  /// Name of volume 1
+    G4String V2Name;  /// Name of volume 2
+    G4int copyNo1;    /// Copy number of volume 1
+    G4int copyNo2;    /// Copy number of volume 2
+
+    /// Points to G4OpticalSurface object
+    G4OpticalSurface* theOptic; 
+    /// Border surface properties
+    G4tgrMaterialPropertiesTable* theMPT = nullptr; 
+
+};
+
+#endif

--- a/source/persistency/ascii/include/G4tgrMaterialFactory.hh
+++ b/source/persistency/ascii/include/G4tgrMaterialFactory.hh
@@ -44,10 +44,14 @@
 #include "G4tgrMaterial.hh"
 #include "G4tgrMaterialSimple.hh"
 #include "G4tgrMaterialMixture.hh"
+#include "G4tgrMaterialPropertiesTable.hh"
+#include "G4tgrBorderSurface.hh"
 
 using G4mstgrisot = std::map<G4String, G4tgrIsotope*>;
 using G4mstgrelem = std::map<G4String, G4tgrElement*>;
 using G4mstgrmate = std::map<G4String, G4tgrMaterial*>;
+using G4mstgrmpt  = std::map<G4String, G4tgrMaterialPropertiesTable*>;
+using G4mstgrbrdr = std::map<G4String, G4tgrBorderSurface*>;
 
 class G4tgrMaterialFactory
 {
@@ -75,6 +79,14 @@ class G4tgrMaterialFactory
       // Build a G4tgrMaterialByWeight or G4tgrMaterialByNoAtoms
       // or G4tgrMaterialByVolume and add it to the Materials list
 
+    G4tgrMaterialPropertiesTable* 
+        AddMaterialPropertiesTable(const std::vector<G4String>& wl);
+      // Build a G4tgrMaterialPropertiesTable and add it to the Materials list
+
+    G4tgrBorderSurface* 
+        AddBorderSurface(const std::vector<G4String>& wl);
+      // Build a G4tgrBorderSurface and add it to the Materials list
+
     G4tgrIsotope* FindIsotope(const G4String& name) const;
       // Look for a G4tgrIsotope and if not found return 0
 
@@ -84,16 +96,32 @@ class G4tgrMaterialFactory
     G4tgrMaterial* FindMaterial(const G4String& name) const;
       // Look for an G4tgrMaterial and if not found return 0
 
+    G4tgrMaterialPropertiesTable* 
+          FindMaterialPropertiesTable(const G4String& name) const;
+      // Look for an G4tgrMaterialPropertiesTable and if not found return 0
+
+    G4tgrBorderSurface* 
+          FindBorderSurface(const G4String& name) const;
+      // Look for an G4tgrBorderSurface and if not found return 0
+
     void DumpIsotopeList() const;
       // Dump detailed list of isotopes
     void DumpElementList() const;
       // Dump detailed list of elements
     void DumpMaterialList() const;
       // Dump detailed list of materials
+    void DumpMaterialPropertiesTableList() const;
+      // Dump detailed list of material property tables
+    void DumpBorderSurfaceList() const;
+      // Dump detailed list of border surfaces
 
     const G4mstgrisot& GetIsotopeList() const { return theG4tgrIsotopes; }
     const G4mstgrelem& GetElementList() const { return theG4tgrElements; }
     const G4mstgrmate& GetMaterialList() const { return theG4tgrMaterials; }
+    const G4mstgrmpt&  GetMaterialPropertyTableList() const 
+          { return theG4tgrMaterialPropertiesTables; }
+    const G4mstgrbrdr&  GetBorderSurfaceList() const 
+          { return theG4tgrBorderSurfaces; }
 
   private:
 
@@ -114,6 +142,10 @@ class G4tgrMaterialFactory
       // List of all G4tgrElements created
     G4mstgrmate theG4tgrMaterials;
       // List of all G4tgrMaterials created
+    G4mstgrmpt  theG4tgrMaterialPropertiesTables;
+      // List of all G4tgrMaterialPropertyTables created
+    G4mstgrbrdr  theG4tgrBorderSurfaces;
+      // List of all G4tgrBorderSurfaces created
 };
 
 #endif

--- a/source/persistency/ascii/include/G4tgrMaterialPropertiesTable.hh
+++ b/source/persistency/ascii/include/G4tgrMaterialPropertiesTable.hh
@@ -1,0 +1,76 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// G4tgrMaterialPropertiesTable
+//
+// Class description:
+// G4tgrMaterialPropertiesTable is a class to register both optical 
+// properties.
+//
+#ifndef G4tgrMaterialPropertiesTable_hh
+#define G4tgrMaterialPropertiesTable_hh 1
+
+#include "globals.hh"
+
+struct ArrayProperty
+{
+  G4String  itemName;   // Key
+  G4double* energies;   // Array of energy values
+  G4double* values;     // Array of property values
+  G4int     arrayCount; // Dimention of arrays
+};
+
+// Contiguous container to store multiple phothon_energy arrays in order
+using G4vpStr2d = std::vector<std::pair<G4String, G4double>>;
+using G4vProp   = std::vector<ArrayProperty>;
+
+class G4tgrMaterialPropertiesTable
+{
+  public:
+
+    G4tgrMaterialPropertiesTable(const std::vector<G4String>&);
+    void G4tgrPopMaterialPropertiesTable(G4int);
+    virtual ~G4tgrMaterialPropertiesTable();
+
+    // Get methods
+    G4int GetNumberOfConstants()  const { return theConstants.size(); }
+    G4int GetNumberOfProperties() const { return theProperties.size(); }
+    G4String GetName()            const { return theName; }
+
+    std::pair<G4String, G4double> GetConstant(G4int i) const {return theConstants[i];}
+    ArrayProperty  GetProperty(G4int i) const {return theProperties[i];}
+
+  protected:
+
+    G4double *energies=NULL; // photon energy values
+    G4String theName;
+    G4int ArrayCount;
+    G4bool photonEnergyUnDefined = true;
+    std::vector<G4String> fwords;
+    G4vpStr2d theConstants;
+    G4vProp   theProperties;
+};
+
+#endif

--- a/source/persistency/ascii/include/G4tgrVolumeMgr.hh
+++ b/source/persistency/ascii/include/G4tgrVolumeMgr.hh
@@ -42,6 +42,8 @@
 #include "G4tgrElement.hh"
 #include "G4tgrMaterial.hh"
 #include "G4tgrRotationMatrix.hh"
+#include "G4tgrMaterialPropertiesTable.hh"
+#include "G4tgrBorderSurface.hh"
 
 #include <map>
 
@@ -100,6 +102,10 @@ class G4tgrVolumeMgr
     void RegisterMe(G4tgrElement* ele) { theHgElemList.push_back(ele); }
     void RegisterMe(G4tgrMaterial* mat) { theHgMateList.push_back(mat); }
     void RegisterMe(G4tgrRotationMatrix* rm) { theHgRotMList.push_back(rm); }
+    void RegisterMe(G4tgrMaterialPropertiesTable* mpt) {
+     theHgMaterialPropertiesTableList.push_back(mpt); }
+    void RegisterMe(G4tgrBorderSurface* brdr) { 
+      theHgBorderSurfaceList.push_back(brdr); }
 
     // Accessors
 
@@ -112,6 +118,10 @@ class G4tgrVolumeMgr
     std::vector<G4tgrElement*> GetElementList() { return theHgElemList; }
     std::vector<G4tgrMaterial*> GetMaterialList() { return theHgMateList; }
     std::vector<G4tgrRotationMatrix*> GetRotMList() { return theHgRotMList; }
+    std::vector<G4tgrMaterialPropertiesTable*> GetMaterialPropertiesTableList() 
+      { return theHgMaterialPropertiesTableList; }
+    std::vector<G4tgrBorderSurface*> 
+      GetBorderSurfaceList() { return theHgBorderSurfaceList; }
 
   private:
 
@@ -140,6 +150,8 @@ class G4tgrVolumeMgr
     std::vector<G4tgrElement*> theHgElemList;
     std::vector<G4tgrMaterial*> theHgMateList;
     std::vector<G4tgrRotationMatrix*> theHgRotMList;
+    std::vector<G4tgrMaterialPropertiesTable*> theHgMaterialPropertiesTableList;
+    std::vector<G4tgrBorderSurface*> theHgBorderSurfaceList;
 };
 
 #endif

--- a/source/persistency/ascii/sources.cmake
+++ b/source/persistency/ascii/sources.cmake
@@ -23,6 +23,8 @@ geant4_add_module(G4geomtext
     G4tgbRotationMatrixMgr.hh
     G4tgbVolume.hh
     G4tgbVolumeMgr.hh
+    G4tgbMaterialPropertiesTable.hh
+    G4tgbBorderSurface.hh
     G4tgrElement.hh
     G4tgrElementFromIsotopes.hh
     G4tgrElementSimple.hh
@@ -52,6 +54,8 @@ geant4_add_module(G4geomtext
     G4tgrVolumeMgr.hh
     G4tgrSolidMultiUnion.hh
     G4tgrSolidScaled.hh
+    G4tgrMaterialPropertiesTable.hh
+    G4tgrBorderSurface.hh
   SOURCES
     G4tgbDetectorBuilder.cc
     G4tgbDetectorConstruction.cc
@@ -73,6 +77,8 @@ geant4_add_module(G4geomtext
     G4tgbRotationMatrixMgr.cc
     G4tgbVolume.cc
     G4tgbVolumeMgr.cc
+    G4tgbMaterialPropertiesTable.cc
+    G4tgbBorderSurface.cc
     G4tgrElement.cc
     G4tgrElementFromIsotopes.cc
     G4tgrElementSimple.cc
@@ -100,6 +106,8 @@ geant4_add_module(G4geomtext
     G4tgrVolumeAssembly.cc
     G4tgrVolumeDivision.cc
     G4tgrVolumeMgr.cc
+    G4tgrMaterialPropertiesTable.cc
+    G4tgrBorderSurface.cc
     G4tgrSolidMultiUnion.cc
     G4tgrSolidScaled.cc)
 

--- a/source/persistency/ascii/src/G4tgbBorderSurface.cc
+++ b/source/persistency/ascii/src/G4tgbBorderSurface.cc
@@ -1,0 +1,115 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// G4tgbBorderSurface
+//
+#include "G4tgbBorderSurface.hh"
+#include "G4tgrMaterialPropertiesTable.hh"
+#include "G4LogicalBorderSurface.hh"
+#include "G4LogicalSkinSurface.hh"
+#include "G4OpticalSurface.hh"
+#include "G4tgbMaterialPropertiesTable.hh"
+
+// ---------------------------------------------------------------------
+G4tgbBorderSurface::G4tgbBorderSurface(G4tgrBorderSurface* tgrbrdr)
+{
+  theTgrBorderSurface = tgrbrdr;
+  theName = tgrbrdr->GetName();
+
+  fOptic = theTgrBorderSurface->GetOptic();
+
+  G4tgrMaterialPropertiesTable *tgrmpt = 
+      theTgrBorderSurface->GetTgrMaterialPropertiesTable();
+  if (tgrmpt)
+  {
+    G4tgbMaterialPropertiesTable* tgbmpt = new 
+                      G4tgbMaterialPropertiesTable(tgrmpt);
+    fOptic->SetMaterialPropertiesTable(
+                      tgbmpt->BuildG4MaterialPropertiesTable());
+  }
+}
+
+// ---------------------------------------------------------------------
+G4tgbBorderSurface::~G4tgbBorderSurface()
+{
+}
+
+// ---------------------------------------------------------------------
+void G4tgbBorderSurface::BuildG4BorderSurface()
+{
+  if (theTgrBorderSurface->GetV1Name() == "skin")
+  {
+  	BuildG4SkinBorderSurface();
+  } else
+  {
+  	BuildG4LogicalBorderSurface();
+  }
+}
+
+// ---------------------------------------------------------------------
+void G4tgbBorderSurface::BuildG4SkinBorderSurface()
+{
+
+  G4LogicalVolume *v1_log = fTgbVolmgr->FindG4LogVol(
+                              theTgrBorderSurface->GetV2Name());
+
+  if (v1_log) { // add some error getting tag
+
+    new G4LogicalSkinSurface(theTgrBorderSurface->GetName(), 
+      v1_log, fOptic);
+    G4cout<<"Border surface "<<theTgrBorderSurface->GetName()<<" around "
+          << theTgrBorderSurface->GetV2Name() << ":" << " added." << G4endl;
+  }
+}
+
+// ---------------------------------------------------------------------
+void G4tgbBorderSurface::BuildG4LogicalBorderSurface()
+{
+
+  G4LogicalVolume *m1 = fTgbVolmgr->FindG4PhysVol(
+                    theTgrBorderSurface->GetV1Name())->GetMotherLogical();
+  G4LogicalVolume *m2 = fTgbVolmgr->FindG4PhysVol(
+                    theTgrBorderSurface->GetV2Name())->GetMotherLogical();
+
+  // search for physics volumes on the sides of the border
+  G4VPhysicalVolume *v1=0, *v2=0;
+  for (int i=0; i<(int)m1->GetNoDaughters(); i++) {
+    v1 = m1->GetDaughter(i);
+    if (v1->GetCopyNo()==theTgrBorderSurface->GetCopyNo1()) break;
+  }
+  for (int i=0; i<(int)m2->GetNoDaughters(); i++) {
+    v2 = m2->GetDaughter(i);
+    if (v2->GetCopyNo()==theTgrBorderSurface->GetCopyNo2()) break;
+  }
+  if (v1 && v2) {
+    new G4LogicalBorderSurface(theTgrBorderSurface->GetName(),
+      v1, v2, fOptic);
+    G4cout<<"Border surface "<<theTgrBorderSurface->GetName()<<" in between "
+        << theTgrBorderSurface->GetV1Name()  << ":"       << 
+           theTgrBorderSurface->GetCopyNo1() << " and "   << 
+           theTgrBorderSurface->GetV2Name()  << ":"       << 
+           theTgrBorderSurface->GetCopyNo2() << " added." << G4endl;
+  }
+}

--- a/source/persistency/ascii/src/G4tgbDetectorBuilder.cc
+++ b/source/persistency/ascii/src/G4tgbDetectorBuilder.cc
@@ -89,5 +89,13 @@ G4tgbDetectorBuilder::ConstructDetector(const G4tgrVolume* tgrVoltop)
   }
 #endif
 
+  // add optical surfaces
+  const G4mstgbbrdr tgrbbdrs = 
+    G4tgbMaterialMgr::GetInstance()->GetG4tgbBorderSurfaceList();
+  for(auto cite = tgrbbdrs.cbegin(); cite != tgrbbdrs.cend(); ++cite)
+  {
+    (*cite).second->BuildG4BorderSurface();
+  }
+
   return physvol;
 }

--- a/source/persistency/ascii/src/G4tgbMaterialPropertiesTable.cc
+++ b/source/persistency/ascii/src/G4tgbMaterialPropertiesTable.cc
@@ -1,0 +1,69 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// G4tgbMaterialPropertiesTable
+//
+#include "G4tgbMaterialPropertiesTable.hh"
+#include "G4tgrMaterialPropertiesTable.hh"
+
+// ---------------------------------------------------------------------
+G4tgbMaterialPropertiesTable::G4tgbMaterialPropertiesTable(
+                                  G4tgrMaterialPropertiesTable* tgrmpt)
+{
+  theTgrTable = tgrmpt;
+  theName = tgrmpt->GetName();
+}
+
+// ---------------------------------------------------------------------
+G4tgbMaterialPropertiesTable::~G4tgbMaterialPropertiesTable()
+{
+}
+
+// ---------------------------------------------------------------------
+G4MaterialPropertiesTable* 
+          G4tgbMaterialPropertiesTable::BuildG4MaterialPropertiesTable()
+{
+  G4int nconst = theTgrTable->GetNumberOfConstants();
+  G4int nprop  = theTgrTable->GetNumberOfProperties();
+
+  for (G4int i=0; i<nconst; ++i)
+  {
+    std::pair<G4String, G4double> theConst = theTgrTable->GetConstant(i);
+    theTable->AddConstProperty(theConst.first, theConst.second);
+    G4cout << "TextGeom: " << theConst.first << "=" << theConst.second 
+           << G4endl;
+  }
+  for (G4int i=0; i<nprop; ++i)
+  {
+    ArrayProperty prop = theTgrTable->GetProperty(i);
+    theTable->AddProperty(prop.itemName, prop.energies, prop.values, 
+                          prop.arrayCount, false, true);
+    G4cout << "TextGeom: " << prop.itemName << "=" << prop.values[0] <<
+           " .. " << prop.values[1] << G4endl;
+  }
+
+  return theTable;
+
+}

--- a/source/persistency/ascii/src/G4tgrBorderSurface.cc
+++ b/source/persistency/ascii/src/G4tgrBorderSurface.cc
@@ -1,0 +1,154 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// G4tgrBorderSurface
+//
+#include "G4tgrBorderSurface.hh"
+#include "G4tgrUtils.hh"
+
+//---------------------------------------------------------------------
+G4tgrBorderSurface::G4tgrBorderSurface(const std::vector<G4String>& wl)
+{
+  // :SURF name physVolu1:CopyNo            // :SURF name skin logVolu
+  //   physVolu2:CopyNo                     //   const_key1 str1
+  //   const_key1 str1                      //   array_key1 array_value1
+  //   array_key1 array_value1
+
+  theName = wl[1];
+  V1Name  = wl[2].substr(0,wl[2].find(":"));
+  V2Name  = wl[3].substr(0,wl[3].find(":"));
+  copyNo1 = atoi(wl[2].substr(wl[2].find(":")+1).data()); // if not return 0
+  copyNo2 = atoi(wl[3].substr(wl[3].find(":")+1).data());
+
+  theOptic = new G4OpticalSurface(wl[1]);
+  
+  size_t i=4;
+  while (i<wl.size()) {
+    G4String setting = wl[i]; 
+    G4String value = wl[i+1];
+    G4StrUtil::to_lower(setting);
+    G4StrUtil::to_lower(value);
+
+    if (setting=="property")    {i++; break;} 
+    else if (setting=="type")   theOptic->SetType(GetType(value));
+    else if (setting=="model")  theOptic->SetModel(glisur);
+    else if (setting=="finish") theOptic->SetFinish(GetFinish(value));
+    else if (setting=="sigma_alpha")
+      theOptic->SetSigmaAlpha(G4tgrUtils::GetInt(value));
+    else
+      G4cout<<"TextGeom: Ignore unknown surface setting "<<value<<G4endl;
+    i+=2;
+  }
+  if (i<wl.size()) { // break while loop because of "property"
+    theMPT = new G4tgrMaterialPropertiesTable(wl);
+    theMPT->G4tgrPopMaterialPropertiesTable(i);
+  }
+}
+
+//---------------------------------------------------------------------
+G4tgrBorderSurface::~G4tgrBorderSurface()
+{
+}
+
+//---------------------------------------------------------------------
+G4SurfaceType G4tgrBorderSurface::GetType(G4String typeStr)
+{
+       if (typeStr == "dielectric_metal")      return dielectric_metal;
+  else if (typeStr == "dielectric_dielectric") return dielectric_dielectric;
+  else if (typeStr == "dielectric_lut")        return dielectric_LUT;
+  else if (typeStr == "dielectric_lutdavis")   return dielectric_LUTDAVIS;
+  else if (typeStr == "dielectric_dichroic")   return dielectric_dichroic;
+  else if (typeStr == "firsov")                return firsov;
+  else if (typeStr == "x_ray")                 return x_ray;
+  else {
+    G4cout << "TextGeom: Unknown surface type: " << typeStr 
+          << " Dielectric_dielectric will be used." << G4endl;
+    return dielectric_dielectric;
+  }
+}
+
+//---------------------------------------------------------------------
+G4OpticalSurfaceFinish G4tgrBorderSurface::GetFinish(G4String finishStr)
+{
+       if (finishStr == "polished")              return polished;
+  else if (finishStr == "polishedfrontpainted")  return polishedfrontpainted;
+  else if (finishStr == "polishedbackpainted")   return polishedbackpainted;
+  else if (finishStr == "ground")                return ground;
+  else if (finishStr == "groundfrontpainted")    return groundfrontpainted;
+  else if (finishStr == "groundbackpainted")     return groundbackpainted;
+  else if (finishStr == "polishedlumirrorair")   return polishedlumirrorair;
+  else if (finishStr == "polishedlumirrorglue")  return polishedlumirrorglue;
+  else if (finishStr == "polishedair")           return polishedair;
+  else if (finishStr == "polishedteflonair")     return polishedteflonair;
+  else if (finishStr == "polishedtioair")        return polishedtioair;
+  else if (finishStr == "polishedtyvekair")      return polishedtyvekair;
+  else if (finishStr == "polishedvm2000air")     return polishedvm2000air;
+  else if (finishStr == "polishedvm2000glue")    return polishedvm2000glue;
+  else if (finishStr == "etchedlumirrorair")     return etchedlumirrorair;
+  else if (finishStr == "etchedlumirrorglue")    return etchedlumirrorglue;
+  else if (finishStr == "etchedair")             return etchedair;
+  else if (finishStr == "etchedteflonair")       return etchedteflonair;
+  else if (finishStr == "etchedtioair")          return etchedtioair;
+  else if (finishStr == "etchedtyvekair")        return etchedtyvekair;
+  else if (finishStr == "etchedvm2000air")       return etchedvm2000air;
+  else if (finishStr == "etchedvm2000glue")      return etchedvm2000glue;
+  else if (finishStr == "groundlumirrorair")     return groundlumirrorair;
+  else if (finishStr == "groundlumirrorglue")    return groundlumirrorglue;
+  else if (finishStr == "groundair")             return groundair;
+  else if (finishStr == "groundteflonair")       return groundteflonair;
+  else if (finishStr == "groundtioair")          return groundtioair;
+  else if (finishStr == "groundtyvekair")        return groundtyvekair;
+  else if (finishStr == "groundvm2000air")       return groundvm2000air;
+  else if (finishStr == "groundvm2000glue")      return groundvm2000glue;
+  else if (finishStr == "rough_lut")             return Rough_LUT;
+  else if (finishStr == "roughteflon_lut")       return RoughTeflon_LUT;
+  else if (finishStr == "roughesr_lut")          return RoughESR_LUT;
+  else if (finishStr == "roughesrgrease_lut")    return RoughESRGrease_LUT;
+  else if (finishStr == "polished_lut")          return Polished_LUT;
+  else if (finishStr == "polishedTeflon_lut")    return PolishedTeflon_LUT;
+  else if (finishStr == "polishedESR_lut")       return PolishedESR_LUT;
+  else if (finishStr == "polishedESRGrease_lut") return PolishedESRGrease_LUT;
+  else if (finishStr == "detector_lut")          return Detector_LUT;
+  else {
+    G4cout << "TextGeom: Unknown surface finish: " << finishStr 
+      << " Polished will be used." << G4endl;
+    return polished;
+  }
+}
+
+//---------------------------------------------------------------------
+G4OpticalSurfaceModel G4tgrBorderSurface::GetModel(G4String modelStr)
+{
+       if (modelStr == "glisur")   return glisur;
+  else if (modelStr == "unified")  return unified;
+  else if (modelStr == "lut")      return LUT;
+  else if (modelStr == "davis")    return DAVIS;
+  else if (modelStr == "dichroic") return dichroic;
+  else {
+    G4cout << "TextGeom: Unknown surface model: " << modelStr 
+      << " Glisur will be used." << G4endl;
+    return glisur;
+  }
+}

--- a/source/persistency/ascii/src/G4tgrLineProcessor.cc
+++ b/source/persistency/ascii/src/G4tgrLineProcessor.cc
@@ -45,6 +45,7 @@
 #include "G4tgrMaterialFactory.hh"
 #include "G4tgrRotationMatrixFactory.hh"
 #include "G4tgrMessenger.hh"
+#include "G4NistManager.hh"
 
 // --------------------------------------------------------------------
 G4tgrLineProcessor::G4tgrLineProcessor()
@@ -196,6 +197,35 @@ G4bool G4tgrLineProcessor::ProcessLine(const std::vector<G4String>& wl)
                   FatalException, wl[1]);
     }
     mate->SetPressure(G4tgrUtils::GetDouble(wl[2], atmosphere));
+
+    //------------------------------- optical properties
+  }
+  else if(wl0 == ":PROP")
+  {
+    G4Material* g4mate = G4NistManager::Instance()->FindOrBuildMaterial(wl[1]);
+    G4tgrMaterial* tgrmate;
+    if(g4mate == nullptr)
+    {
+      tgrmate = G4tgrMaterialFactory::GetInstance()->FindMaterial(
+        G4tgrUtils::GetString(wl[1]));
+    }
+
+    if(g4mate == nullptr && tgrmate == nullptr)
+    {
+      G4Exception("G4tgrLineProcessor::ProcessLine()", "Material not found",
+                  FatalException, wl[1]);
+    }
+
+    G4tgrMaterialPropertiesTable* tgrmpt = 
+      G4tgrMaterialFactory::GetInstance()->AddMaterialPropertiesTable(wl);
+    volmgr->RegisterMe(tgrmpt);
+
+    //------------------------------- optical surface
+  }
+  else if(wl0 == ":SURF")
+  {
+    G4tgrBorderSurface *brdr = G4tgrMaterialFactory::GetInstance()->AddBorderSurface(wl);
+    volmgr->RegisterMe(brdr); // add to volume manager
 
     //------------------------------- solid
   }

--- a/source/persistency/ascii/src/G4tgrMaterialFactory.cc
+++ b/source/persistency/ascii/src/G4tgrMaterialFactory.cc
@@ -180,6 +180,61 @@ G4tgrMaterialFactory::AddMaterialMixture(const std::vector<G4String>& wl,
 }
 
 // --------------------------------------------------------------------
+G4tgrMaterialPropertiesTable*
+G4tgrMaterialFactory::AddMaterialPropertiesTable(
+                                        const std::vector<G4String>& wl)
+{
+#ifdef G4VERBOSE
+  if(G4tgrMessenger::GetVerboseLevel() >= 2)
+  {
+    G4cout << " G4tgrMaterialFactory::AddtgrMaterialPropertiesTable " 
+           << wl[1] << G4endl;
+  }
+#endif
+
+  //---------- Look if material properties table already exists
+  if(FindMaterialPropertiesTable(G4tgrUtils::GetString(wl[1])) != 0)
+  {
+    ErrorAlreadyExists("Material Properties Table ", wl);
+  }
+
+  G4tgrMaterialPropertiesTable* tgrmpt;
+  tgrmpt = new G4tgrMaterialPropertiesTable(wl);
+
+  //---------- register this G4tgrMaterialPropertiesTable
+  theG4tgrMaterialPropertiesTables[tgrmpt->GetName()] = tgrmpt;
+
+  return tgrmpt;
+}
+
+// --------------------------------------------------------------------
+G4tgrBorderSurface*
+G4tgrMaterialFactory::AddBorderSurface(const std::vector<G4String>& wl)
+{
+#ifdef G4VERBOSE
+  if(G4tgrMessenger::GetVerboseLevel() >= 2)
+  {
+    G4cout << " G4tgrMaterialFactory::AddtgrBorderSurface " 
+           << wl[1] << G4endl;
+  }
+#endif
+
+  //---------- Look if surface already exists
+  if(FindBorderSurface(G4tgrUtils::GetString(wl[1])) != 0)
+  {
+    ErrorAlreadyExists("Material Properties Table ", wl);
+  }
+
+  G4tgrBorderSurface* tgrbrdr;
+  tgrbrdr = new G4tgrBorderSurface(wl);
+
+  //---------- register this G4tgrBorderSurface
+  theG4tgrBorderSurfaces[tgrbrdr->GetName()] = tgrbrdr;
+
+  return tgrbrdr;
+}
+
+// --------------------------------------------------------------------
 G4tgrIsotope* G4tgrMaterialFactory::FindIsotope(const G4String& name) const
 {
 #ifdef G4VERBOSE
@@ -259,6 +314,50 @@ G4tgrMaterial* G4tgrMaterialFactory::FindMaterial(const G4String& name) const
 }
 
 // --------------------------------------------------------------------
+G4tgrMaterialPropertiesTable* G4tgrMaterialFactory::FindMaterialPropertiesTable(
+                                            const G4String& name) const
+{
+#ifdef G4VERBOSE
+  if(G4tgrMessenger::GetVerboseLevel() >= 3)
+  {
+    G4cout << " G4tgrMaterialFactory::FindMaterialPropertiesTable() - " << name << G4endl;
+  }
+#endif
+  G4mstgrmpt::const_iterator cite;
+  cite = theG4tgrMaterialPropertiesTables.find(name);
+  if(cite == theG4tgrMaterialPropertiesTables.cend())
+  {
+    return nullptr;
+  }
+  else
+  {
+    return (*cite).second;
+  }
+}
+
+// --------------------------------------------------------------------
+G4tgrBorderSurface* G4tgrMaterialFactory::FindBorderSurface(
+                                            const G4String& name) const
+{
+#ifdef G4VERBOSE
+  if(G4tgrMessenger::GetVerboseLevel() >= 3)
+  {
+    G4cout << " G4tgrMaterialFactory::FindBorderSurface() - " << name << G4endl;
+  }
+#endif
+  G4mstgrbrdr::const_iterator cite;
+  cite = theG4tgrBorderSurfaces.find(name);
+  if(cite == theG4tgrBorderSurfaces.cend())
+  {
+    return nullptr;
+  }
+  else
+  {
+    return (*cite).second;
+  }
+}
+
+// --------------------------------------------------------------------
 void G4tgrMaterialFactory::DumpIsotopeList() const
 {
   G4cout << " @@@@@@@@@@@@@@@@ DUMPING G4tgrIsotope's List " << G4endl;
@@ -290,6 +389,35 @@ void G4tgrMaterialFactory::DumpMaterialList() const
     G4tgrMaterial* mate = (*cite).second;
     G4cout << " MATE: " << mate->GetName() << " Type: " << mate->GetType()
            << " NoComponents= " << mate->GetNumberOfComponents() << G4endl;
+  }
+}
+
+// --------------------------------------------------------------------
+void G4tgrMaterialFactory::DumpMaterialPropertiesTableList() const
+{
+  G4cout << " @@@@@@@@@@@@@@@@ DUMPING G4tgrMaterialPropertiesTable's List " << G4endl;
+  for(auto cite = theG4tgrMaterialPropertiesTables.cbegin();
+           cite != theG4tgrMaterialPropertiesTables.cend(); ++cite)
+  {
+    G4tgrMaterialPropertiesTable* mpt = (*cite).second;
+    G4cout << " PROP: " << mpt->GetName()
+           << " Number Of Constants = " <<  mpt->GetNumberOfConstants() 
+           << " Number Of Properties = " << mpt->GetNumberOfProperties() << G4endl;
+  }
+}
+
+// --------------------------------------------------------------------
+void G4tgrMaterialFactory::DumpBorderSurfaceList() const
+{
+  G4cout << " @@@@@@@@@@@@@@@@ DUMPING G4tgrBorderSurface's List " << G4endl;
+  for(auto cite = theG4tgrBorderSurfaces.cbegin();
+           cite != theG4tgrBorderSurfaces.cend(); ++cite)
+  {
+    G4tgrBorderSurface* brdr = (*cite).second;
+    G4cout << " SURF: " << brdr->GetName()
+           << " First Volume = " <<  brdr->GetV1Name() 
+           << " Seccond Volume = " <<  brdr->GetV2Name() 
+           << G4endl;
   }
 }
 

--- a/source/persistency/ascii/src/G4tgrMaterialPropertiesTable.cc
+++ b/source/persistency/ascii/src/G4tgrMaterialPropertiesTable.cc
@@ -1,0 +1,93 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// G4tgrMaterialPropertiesTable
+//
+#include "G4tgrMaterialPropertiesTable.hh"
+#include "G4tgrUtils.hh"
+
+//---------------------------------------------------------------------
+G4tgrMaterialPropertiesTable::G4tgrMaterialPropertiesTable(const std::vector<G4String>& wl)
+{
+  // :PROP name
+  //   const_name1 value1
+  //   array_name1 array_values1
+  fwords = wl;
+  //---------- Set name
+  theName = G4tgrUtils::GetString(fwords[1]);
+  G4cout << "Setting optical properties of " << theName << ":" << G4endl;
+  G4tgrPopMaterialPropertiesTable(2);
+}
+  
+//---------------------------------------------------------------------
+G4tgrMaterialPropertiesTable::~G4tgrMaterialPropertiesTable()
+{
+}
+
+//---------------------------------------------------------------------
+void G4tgrMaterialPropertiesTable::G4tgrPopMaterialPropertiesTable(G4int idx)
+{
+    for (size_t i=idx; i<fwords.size(); i++) {
+    G4String item_name = fwords[i];
+    G4StrUtil::to_upper(item_name);
+    if (G4StrUtil::contains(item_name, "SCINTILLATIONYIELD") 
+      || item_name=="RESOLUTIONSCALE" 
+      || G4StrUtil::contains(item_name, "TIMECONSTANT") 
+      || G4StrUtil::contains(item_name, "MIEHG_") 
+      || G4StrUtil::contains(item_name, "SCINTILLATIONRISETIME")) {
+      theConstants.emplace_back(item_name, G4tgrUtils::GetDouble(fwords[i+1]));
+      G4cout << "TextGeom: " << item_name << "=" << fwords[i+1] << G4endl;
+      i++; // item_name value has been used
+    } else if (item_name.substr(0,12)=="PHOTON_ENERG") {
+      photonEnergyUnDefined=false;
+      ArrayCount = G4tgrUtils::GetInt(fwords[i+1]);
+      energies = new double[ArrayCount]; // create energy array
+      
+      for (int j=0; j<ArrayCount; j++)
+        energies[j]=G4tgrUtils::GetDouble(fwords[i+2+j]);
+      i=i+1+ArrayCount; // array has been used
+    } else { // wavelength-dependent properties
+      if (photonEnergyUnDefined) {
+        G4cout<<"TextGeom: photon energies undefined, "
+          <<"ignore all wavelength-dependent properties!"<<G4endl;
+        break;
+      }
+      ArrayProperty ap; 
+      ap.itemName = item_name;
+      ap.arrayCount = ArrayCount;
+      ap.values   = new double[ArrayCount];
+      ap.energies = new double[ArrayCount];
+      for (int j=0; j<ArrayCount; j++)
+      {
+        ap.values[j] = G4tgrUtils::GetDouble(fwords[i+1+j]);
+        ap.energies[j] = energies[j];
+      }
+      theProperties.push_back(ap);
+      i=i+ArrayCount;
+    }
+  }
+}
+
+  


### PR DESCRIPTION
This PR adds optical tags (:prop and :surf) to text geometry description, these tags can be used for implementing [G4MaterialPropertiesTable](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/TrackingAndPhysics/physicsProcess.html?highlight=g4materialpropertiestable#defining-material-properties), [G4LogicalBorderSurface](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/TrackingAndPhysics/physicsProcess.html?highlight=g4materialpropertiestable#specifying-the-surface) and G4LogicalSkinSurface. 

The code was first developed as a toolkit called [gears](http://physino.xyz/gears/) by Dr. [Jing Liu](https://www.usd.edu/faculty-and-staff/Jing-Liu) at South Dakota University and I have the [permission](https://youtu.be/uL2THhm2EwE) to modify and publish it (in the comments below the video).