### PR TITLE
Fix macroPath not influencing macro commands if and strif

### DIFF
--- a/source/intercoms/src/G4UIcontrolMessenger.cc
+++ b/source/intercoms/src/G4UIcontrolMessenger.cc
@@ -576,7 +576,7 @@ void G4UIcontrolMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
     else if(comp == "!=")
       x = (l != r);
     if(x)
-      UI->ExecuteMacroFile(mac);
+      UI->ExecuteMacroFile(UI->FindMacroPath(mac));
   }
   if(command == doifCommand)
   {
@@ -699,7 +699,7 @@ void G4UIcontrolMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
       x = (l != r);
     }
     if(x)
-      UI->ExecuteMacroFile(mac);
+      UI->ExecuteMacroFile(UI->FindMacroPath(mac));
   }
   if(command == strdoifCommand)
   {


### PR DESCRIPTION
Using /control/if or /control/strif does not find macro files in destinations specified in macroPath. This simple fix wraps the files given in the command in a FindMacroPath command in order to search all paths in macroPath.