### PR TITLE
Adding guard for optical properties user's inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -333,3 +333,6 @@ CTestTestfile.cmake
 *.su
 *.idb
 *.pdb
+
+# CLION
+.idea/

--- a/source/materials/src/G4MaterialPropertiesTable.cc
+++ b/source/materials/src/G4MaterialPropertiesTable.cc
@@ -308,6 +308,20 @@ G4MaterialPropertyVector* G4MaterialPropertiesTable::AddProperty(
                 FatalException, ed);
   }
 
+  bool isInverted = false;
+  for (unsigned int i = 0; i < photonEnergies.size() - 1; ++i) {
+    if (photonEnergies.at(i + 1) < photonEnergies.at(i)) {
+      isInverted = true;
+      break;
+    }
+  }
+  if (isInverted) {
+    G4ExceptionDescription ed;
+    ed << "AddProperty warning: Photon energy array is in descending order!";
+    G4Exception("G4MaterialPropertiesTable::AddProperty()", "mat215",
+                JustWarning, ed);
+  }
+
   // if the key doesn't exist, add it if requested
   if(std::find(fMatPropNames.begin(), fMatPropNames.end(), key) ==
      fMatPropNames.end())


### PR DESCRIPTION
I recently wrote a scintillator simulation. The bug I created is: all the scintillation photons created are of the same wavelength. After some debugging, it turns out that the bug is caused by my input material properties data. I arranged them all in the ascending order of wavelengths (so they are in the descending order of photon energies). After reversing the order of the array, I was able to get the scintillation spectrum as I input, ([Ref](https://github.com/dungducphan/ddfusion_opticalsim/commit/a13f8110414217f355a24743a75554b678d22c5f), see lines 121-126).

The problem I had during the debugging is it's very hard to pinpoint the cause of the problem. There are no error/warning from Geant4. The documentation [Physics Processes](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/TrackingAndPhysics/physicsProcess.html#optical-photon-processes) also does not explicitly remind the users to use ascending order of photon energies.

So the reason for this pull request.

The other minor change: ignoring the `.idea/` directory for users who use CLion.