### PR TITLE
Uninitialized memory in zlib

### DIFF
--- a/source/externals/zlib/src/deflate.c
+++ b/source/externals/zlib/src/deflate.c
@@ -319,6 +319,10 @@ int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
 
     s->window = (Bytef *) ZALLOC(strm, s->w_size, 2*sizeof(Byte));
     s->prev   = (Posf *)  ZALLOC(strm, s->w_size, sizeof(Pos));
+    /* Avoid use of uninitialized value, see:
+     * https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11360
+     */
+    zmemzero(s->prev, s->w_size * sizeof(Pos));
     s->head   = (Posf *)  ZALLOC(strm, s->hash_size, sizeof(Pos));
 
     s->high_water = 0;      /* nothing written to s->window yet */


### PR DESCRIPTION
## Problem
I'm currently scanning the Geant4-based toolkit **GATE** using the memory checker **Valgrind** (see https://github.com/OpenGATE/Gate/issues/480, https://github.com/OpenGATE/gam-gate/issues/8). This brought up several *Conditional jump or move depends on uninitialised value(s)* messages like [this one](https://github.com/Geant4/geant4/files/8206317/message.txt). 

The expected result of the Valgrind scan is that no such messages come up:
- If a message is a true positive, this could introduce undefined (e.g., non-deterministic) behaviour.
- If a message is a false positive, it draws attention from true positives.


## What is wrong here?

This is a known false positive in zlib. A buffer allocated [here](https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/deflate.c#L322) is not initialized when [this](https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/deflate.c#L219) do-while loop modifies it using the `?:` operator, and that's what Valgrind reports. As the modification just applies a function `m`->`(m>=wsize ? m-wsize : 0)` to each element of the buffer, this is not dangerous - undefined elements will remain undefined, but that's it. 

Therefore, the valgrind message for this known zlib trickyness is usually suppressed; e.g. on my system, `/usr/libexec/valgrind/default.supp` contains [these](https://github.com/tklengyel/valgrind/blob/971c165fc4335bf04bedf58e0800a12776fce408/xfree-4.supp#L328) lines. The suppression mechanism recognizes the false positive by the combination of the function name `slide_hash` and the library path `/*lib*/libz.so.1.2.*`. As the library is named `libG4zlib.so` in Geant4, the false positive is not recognized.

## Proposed changes
Patch zlib to initialize the buffer with zeros, as in the Chromium [patch](https://github.com/chromium/chromium/blob/main/third_party/zlib/patches/0003-uninitializedjump.patch) that is referenced below. 

## Related work
- The [zlib FAQ](https://zlib.net/zlib_faq.html#faq36) say that 
  > versions 1.2.4 and later was changed to not stimulate these checkers  
  
  I'm not sure if this is correct. As soon as I build and link the current zlib-1.2.11 shared object with a different file name and soname (in a minimal example), the valgrind message shows up.

- There is already an upstream PR https://github.com/madler/zlib/pull/393, however without activity for the last two years.

- As stated in that PR, Chromium uses a modified version of zlib and [one of their patches](https://github.com/chromium/chromium/blob/main/third_party/zlib/patches/0003-uninitializedjump.patch) addresses this issue.

## Additional checks
Note that the Geant4 zlib in `source/externals/zlib` differs from the original zlib-1.2.11 ([sources](https://zlib.net/zlib-1.2.11.tar.gz)) in various ways:
- the files were sorted into a `src` and `include` directory
- Some casts were added at various places.
- `gzread.c` and `gzwrite.c` were modified even more.
- A CMake build system is used.

When I replaced the modified files with the original ones, the `libG4zlib.so` could still be compiled and linked and the error message remained.