### PR TITLE
Fix geant4 build on mingw

### DIFF
--- a/source/externals/clhep/include/CLHEP/Utility/thread_local.h
+++ b/source/externals/clhep/include/CLHEP/Utility/thread_local.h
@@ -7,7 +7,7 @@
 //
 // ======================================================================
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 7) || __clang__ || WIN32
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 7) || __clang__ || defined(WIN32) || defined(__MINGW32__)
   #define CLHEP_THREAD_LOCAL thread_local
 #else
   #define CLHEP_THREAD_LOCAL

--- a/source/externals/g4tools/include/tools/wroot/date
+++ b/source/externals/g4tools/include/tools/wroot/date
@@ -22,7 +22,7 @@ inline date get_date(){
   // Date is stored with the origin being the 1st january 1995.
   // Time has 1 second precision.
   time_t tloc = ::time(0);
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
   struct tm *tp = (tm*)::localtime(&tloc); //not thread safe (but exist on Windows).
 #else
   struct tm tpa;

--- a/source/global/HEPRandom/src/G4UniformRandPool.cc
+++ b/source/global/HEPRandom/src/G4UniformRandPool.cc
@@ -46,7 +46,7 @@ void create_pool(G4double*& buffer, G4int ps) { buffer = new G4double[ps]; }
 
 void destroy_pool(G4double*& buffer) { delete[] buffer; }
 
-#if defined(WIN32)
+#if defined(WIN32) || defined(__MINGW32__)
 // No bother with WIN
 void create_pool_align(G4double*& buffer, G4int ps) { create_pool(buffer, ps); }
 void destroy_pool_align(G4double*& buffer) { destroy_pool(buffer); }

--- a/source/global/management/include/G4SliceTimer.hh
+++ b/source/global/management/include/G4SliceTimer.hh
@@ -39,7 +39,7 @@
 #ifndef G4SLICE_TIMER_HH
 #define G4SLICE_TIMER_HH 1
 
-#ifndef WIN32
+#if !(defined(WIN32) || defined(__MINGW32__))
 #  include <sys/times.h>
 #  include <unistd.h>
 #else

--- a/source/global/management/include/G4Timer.hh
+++ b/source/global/management/include/G4Timer.hh
@@ -72,7 +72,7 @@
 #ifndef G4TIMER_HH
 #define G4TIMER_HH 1
 
-#ifndef WIN32
+#if !(defined(WIN32) || defined(__MINGW32__))
 #  include <sys/times.h>
 #  include <unistd.h>
 #else

--- a/source/global/management/src/G4Threading.cc
+++ b/source/global/management/src/G4Threading.cc
@@ -34,7 +34,7 @@
 #include "G4AutoLock.hh"
 #include "globals.hh"
 
-#if defined(WIN32)
+#if defined(WIN32) || defined(__MINGW32__)
 #  include <Windows.h>
 #else
 #  include <sys/syscall.h>

--- a/source/interfaces/basic/include/G4UItcsh.hh
+++ b/source/interfaces/basic/include/G4UItcsh.hh
@@ -29,7 +29,7 @@
 #ifndef G4UItcsh_h
 #define G4UItcsh_h 1
 
-#ifndef WIN32
+#if !(defined(WIN32) || defined(__MINGW32__))
 
 #include <termios.h>
 #include <vector>

--- a/source/interfaces/basic/src/G4UIExecutive.cc
+++ b/source/interfaces/basic/src/G4UIExecutive.cc
@@ -134,7 +134,7 @@ G4UIExecutive::G4UIExecutive(G4int argc, char** argv, const G4String& type)
 #endif
     break;
  case kTcsh:
-#ifndef WIN32
+#if !(defined(WIN32) || defined(__MINGW32__))
     DISCARD_PARAMETER(argc);
     DISCARD_PARAMETER(argv);
     shell = new G4UItcsh;

--- a/source/processes/hadronic/models/lend/src/MCGIDI_map.cc
+++ b/source/processes/hadronic/models/lend/src/MCGIDI_map.cc
@@ -12,7 +12,7 @@
 #define PATH_MAX 4096
 #endif
 
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
 #include <windows.h>
 #define realpath( a, b ) GetFullPathName( a, PATH_MAX, b, NULL )
 #endif

--- a/source/processes/hadronic/models/lend/src/xDataTOM.cc
+++ b/source/processes/hadronic/models/lend/src/xDataTOM.cc
@@ -11,7 +11,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
 #include <windows.h>
 #define realpath( a, b ) GetFullPathName( a, PATH_MAX, b, NULL )
 #define strtoll _strtoi64

--- a/source/processes/hadronic/models/lend/src/xDataTOM_importXML.cc
+++ b/source/processes/hadronic/models/lend/src/xDataTOM_importXML.cc
@@ -11,7 +11,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#ifdef WIN32
+#if defined(WIN32) || defined(__MINGW32__)
 #include <BaseTsd.h>
 #include <io.h>
 #include <windows.h>


### PR DESCRIPTION
See also https://geant4-forum.web.cern.ch/t/fixing-geant4-build-on-mingw/8662

After trying to build Geant4 on win10 with MinGW (MSYS2) and GCC 12.2, I realized that WIN32 macro definition is missing on MinGW, however it is used by G4 to distinguish the code routines under the windows platform.
I tried to fix the issue by simply changing some preprocessor macros, and it passed the compilation successfully.
(however, with gcc flag -fpermissive, which is not very surprising).
I generally think that these changes will not destroy the compilation results on other platforms. However, I except that someone who is very familiar with Geant4 build could review these changes to avoid any possible issues.