### PR TITLE
Fix typos in source/visualization subdirectory

### DIFF
--- a/source/visualization/FukuiRenderer/CUSTOMIZE
+++ b/source/visualization/FukuiRenderer/CUSTOMIZE
@@ -101,7 +101,7 @@
 #
 #        setenv G4DAWNFILE_MAX_FILENUM  1
 #
-#      The dafault value is "0", i.e., the batch mode is off.
+#      The default value is "0", i.e., the batch mode is off.
 #
 #  Example:
 #
@@ -190,14 +190,14 @@
 
 ###############################################
 ## Environmental variables to CUSTOMIZE      ##
-## Geant4 DAWN-Network visualization driver  ##  
+## Geant4 DAWN-Network visualization driver  ##
 ##                                           ##
 ##  Note: This driver should be used only    ##
-##        for remote visualizaton.)          ##
+##        for remote visualization.)         ##
 ###############################################
 
 #----- << G4DAWN_GUI_ALWAYS >>
-#      Boolean flag to control GUI invokation.
+#      Boolean flag to control GUI invocation.
 #      If this variable is set and the value is non-zero,
 #      DAWN connected with GEANT4 always pops up GUI menu.
 #      The default is "0", i.e., no GUI.

--- a/source/visualization/OpenGL/Doxyfile
+++ b/source/visualization/OpenGL/Doxyfile
@@ -723,7 +723,7 @@ COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
 
 # Load stylesheet definitions from file. Syntax is similar to doxygen's 
-# config file, i.e. a series of assigments. You only have to provide 
+# config file, i.e. a series of assignments. You only have to provide 
 # replacements, missing definitions are set to their default value.
 
 RTF_STYLESHEET_FILE    = 
@@ -908,7 +908,7 @@ EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 
 #---------------------------------------------------------------------------
-# Configuration::addtions related to external references   
+# Configuration::additions related to external references   
 #---------------------------------------------------------------------------
 
 # The TAGFILES option can be used to specify one or more tagfiles. 
@@ -990,7 +990,7 @@ CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
 
 # If the UML_LOOK tag is set to YES doxygen will generate inheritance and 
-# collaboration diagrams in a style similiar to the OMG's Unified Modeling 
+# collaboration diagrams in a style similar to the OMG's Unified Modeling 
 # Language.
 
 UML_LOOK               = NO
@@ -1084,7 +1084,7 @@ GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES
 
 #---------------------------------------------------------------------------
-# Configuration::addtions related to the search engine   
+# Configuration::additions related to the search engine   
 #---------------------------------------------------------------------------
 
 # The SEARCHENGINE tag specifies whether or not a search engine should be 

--- a/source/visualization/OpenGL/include/G4OpenGLQtExportDialog.hh
+++ b/source/visualization/OpenGL/include/G4OpenGLQtExportDialog.hh
@@ -43,7 +43,7 @@ class QLineEdit;
 
 class QGroupBox;
 
-/** The G4OpenGLQtExportDialog class provide a Dialog displaying differents options
+/** The G4OpenGLQtExportDialog class provide a Dialog displaying different options
     for each file format
 */
 class G4OpenGLQtExportDialog : public QDialog
@@ -73,7 +73,7 @@ class G4OpenGLQtExportDialog : public QDialog
       the original value  */
   int getHeight();
 
-  /** return if vector EPS is checked, if button does'nt exist, return 0 */
+  /** return if vector EPS is checked, if button doesn't exist, return 0 */
   bool getVectorEPS();
 
   public Q_SLOTS:

--- a/source/visualization/OpenGL/include/G4OpenGLQtMovieDialog.hh
+++ b/source/visualization/OpenGL/include/G4OpenGLQtMovieDialog.hh
@@ -39,7 +39,7 @@ class G4OpenGLQtViewer;
 
 class QGroupBox;
 
-/** The G4OpenGLQtMovieDialog class provide a Dialog displaying differents options
+/** The G4OpenGLQtMovieDialog class provide a Dialog displaying different options
     for each file format
 */
 class G4OpenGLQtMovieDialog : public QDialog

--- a/source/visualization/OpenGL/include/G4OpenGLQtViewer.hh
+++ b/source/visualization/OpenGL/include/G4OpenGLQtViewer.hh
@@ -247,10 +247,10 @@ private:
   void clearSceneTreeSelection(QTreeWidgetItem*);
   void clearTreeWidgetElements(QTreeWidgetItem* item);
 
-  // Get the tree wigdet item for POindex if exists
+  // Get the tree widget item for POindex if exists
   QTreeWidgetItem* getTreeWidgetItem(int POindex);
 
-  // Get the old tree wigdet item for POindex if exists
+  // Get the old tree widget item for POindex if exists
   QTreeWidgetItem* getOldTreeWidgetItem(int POindex);
 
 // parse the scene tree and return a string of status that can be saved

--- a/source/visualization/OpenGL/include/G4OpenGLSceneHandler.hh
+++ b/source/visualization/OpenGL/include/G4OpenGLSceneHandler.hh
@@ -142,7 +142,7 @@ protected:
   void ClearAndDestroyAtts();  // Destroys att holders and clears pick map.
   
 #ifdef G4OPENGL_VERSION_2
-  // Special case for VBO, we want to have acces to the VBO drawer everywhere
+  // Special case for VBO, we want to have access to the VBO drawer everywhere
   // because instead of OpenGL call which are static, VBO openGL functions :
   // - Are functions of an WGLWidget object(G4OpenGLImmediateViewer in our case)
   // - Needs an access to the QGLSHader

--- a/source/visualization/OpenGL/include/G4OpenGLViewer.hh
+++ b/source/visualization/OpenGL/include/G4OpenGLViewer.hh
@@ -158,7 +158,7 @@ protected:
   bool setExportFilename(G4String name,G4bool inc = true);
   // set export filename.
   // if inc, then the filename will be increment by one each time
-  // try to guesss the correct format according to the extention
+  // try to guess the correct format according to the extension
 
   std::string getRealPrintFilename();
   unsigned int getWinWidth() const;

--- a/source/visualization/OpenGL/src/G4OpenGLImmediateQtViewer.cc
+++ b/source/visualization/OpenGL/src/G4OpenGLImmediateQtViewer.cc
@@ -54,7 +54,7 @@ G4OpenGLImmediateQtViewer::G4OpenGLImmediateQtViewer
 {
   fQGLWidgetInitialiseCompleted = false;
 
-  setFocusPolicy(Qt::StrongFocus); // enable keybord events
+  setFocusPolicy(Qt::StrongFocus); // enable keyboard events
   fHasToRepaint = false;
   fPaintEventLock = false;
 
@@ -143,7 +143,7 @@ void G4OpenGLImmediateQtViewer::initializeGL () {
 
   // Set the component visible
   
-  // and update it immediatly before wait for SessionStart() (batch mode)
+  // and update it immediately before wait for SessionStart() (batch mode)
 //  QCoreApplication::sendPostedEvents () ;
 
   // Set jpg as default export format for Qt viewer

--- a/source/visualization/OpenGL/src/G4OpenGLQtViewer.cc
+++ b/source/visualization/OpenGL/src/G4OpenGLQtViewer.cc
@@ -599,7 +599,7 @@ void G4OpenGLQtViewer::createPopupMenu()    {
     createRadioAction(fProjectionOrtho, fProjectionPerspective,SLOT(toggleProjection(bool)),2);
   }
 #else
-  // no more radioAction, not realy useful and could be confusing to use context menu and icon at the same time
+  // no more radioAction, not really useful and could be confusing to use context menu and icon at the same time
   fProjectionOrtho = mProjection->addAction("Orthographic", this, [this](){ this->toggleProjection(1); });
   fProjectionPerspective = mProjection->addAction("Perspective", this, [this](){ this->toggleProjection(2); });
 #endif
@@ -1703,7 +1703,7 @@ void G4OpenGLQtViewer::G4keyPressEvent (QKeyEvent * evnt)
       rotateQtSceneToggle(-fRot_sens,0);
     }
 
-    // Rotatio +/-
+    // Rotation +/-
     if (evnt->key() == Qt::Key_Plus) {
       fRot_sens = fRot_sens/0.7;
       G4cout << "Auto-rotation set to : " << fRot_sens << G4endl;
@@ -2178,8 +2178,8 @@ QString G4OpenGLQtViewer::removeTempFolder() {
 }
 
 /**
-  Export image. Try to get the format according to the file extention.
-  If not present, the last one choosen by /vis/ogl/set/exportFormat
+  Export image. Try to get the format according to the file extension.
+  If not present, the last one chosen by /vis/ogl/set/exportFormat
   If not, will take the default format : eps
   Best format actually available is pdf (vectored and allow transparency)
   If name is not set, it will take the default name value given by /vis/ogl/set/printFilename
@@ -2190,7 +2190,7 @@ bool G4OpenGLQtViewer::exportImage(std::string name, int width, int height) {
   if (! qGLW) {
     return false;
   }
-  // If there is already an extention
+  // If there is already an extension
   bool increaseFileNumber = true;
   // if
   if (name.size() != name.substr(name.find_last_of(".") + 1).size()) {
@@ -2603,7 +2603,7 @@ void G4OpenGLQtViewer::createSceneTreeComponent(){
   fSceneTreeComponentTreeWidget->setHeaderLabel ("Scene tree : "+QString(GetName().data()));
   fSceneTreeComponentTreeWidget->setColumnHidden (1,true);  // copy number
   fSceneTreeComponentTreeWidget->setColumnHidden (2,true);  // PO index
-  fSceneTreeComponentTreeWidget->setColumnHidden (3,true);  // Informations
+  fSceneTreeComponentTreeWidget->setColumnHidden (3,true);  // Information
   //   data(0) : POindex
   //   data(1) : copy number
   //   data(2) : g4color
@@ -2983,7 +2983,7 @@ QTreeWidgetItem* G4OpenGLQtViewer::createTreeWidgetItem(
     newItem->setToolTip (0,QString("double-click to change the color"));
   }
 
-  // special case: if alpha=0, it is a totally transparent objet,
+  // special case: if alpha=0, it is a totally transparent object,
   // then, do not redraw it
   if (color.GetAlpha() == 0) {
     state = Qt::Unchecked;
@@ -3040,7 +3040,7 @@ bool G4OpenGLQtViewer::parseAndInsertInSceneTree(
   // - if so, go into this child
   // - if not : create it as invisible
 
-  // Realy quick check if the POindex is already there
+  // Really quick check if the POindex is already there
   QTreeWidgetItem* subItem = NULL;
   QList<QTreeWidgetItem *> parentItemList;
 
@@ -3218,7 +3218,7 @@ void G4OpenGLQtViewer::changeOpenCloseVisibleHiddenSelectedColorSceneTreeElement
     }
   }
 
-  // if found : retore old state
+  // if found : restore old state
   if (oldItem != NULL) {
     subItem->setFlags(oldItem->flags());   // flags
     subItem->setCheckState(0,oldItem->checkState(0)); // check state
@@ -3799,7 +3799,7 @@ void G4OpenGLQtViewer::changeDepthOnSceneTreeItem(
   double transparencyLevel = 0.;
 
   // look for a 2.2 depth and we are at level 3
-  // -> Set all theses items to Opaque
+  // -> Set all these items to Opaque
   // ONLY if it is a PV volume !
   if (isPVVolume(item)) {
     if ((lookForDepth-currentDepth) < 0) {
@@ -3898,7 +3898,7 @@ void G4OpenGLQtViewer::clearTreeWidget(){
       }
       fPositivePoIndexSceneTreeWidgetQuickMap.clear();
 
-      // put correct value in paramaters
+      // put correct value in parameters
       fOldLastSceneTreeWidgetAskForIterator = fOldPositivePoIndexSceneTreeWidgetQuickMap.begin();
       fOldLastSceneTreeWidgetAskForIteratorEnd = fOldPositivePoIndexSceneTreeWidgetQuickMap.end();
       fSceneTreeDepth = 1;
@@ -4746,7 +4746,7 @@ bool G4OpenGLQtViewer::isCurrentWidget(){
 }
 
 /**   Build the parameter list parameters in a QString<br>
- Reimplement partialy the G4UIparameter.cc
+ Reimplement partially the G4UIparameter.cc
  @param aCommand : command to list parameters
  @see G4UIparameter::List()
  @see G4UIcommand::List()

--- a/source/visualization/OpenGL/src/G4OpenGLSceneHandler.cc
+++ b/source/visualization/OpenGL/src/G4OpenGLSceneHandler.cc
@@ -1165,7 +1165,7 @@ void G4OpenGLSceneHandler::glEndVBO()  {
       for (unsigned int a=0; a<fOglVertex.size(); a+=6*4) {
         vertices.insert (vertices.end(),fOglVertex.begin()+a,fOglVertex.begin()+a+1*6+6); // 0-1
         // if 2-3 == 4-5, do not add them
-        // if differents, we are obliged to create a new GL_TRIANGLE_STRIP
+        // if different, we are obliged to create a new GL_TRIANGLE_STRIP
         if (a+4*6+5 < fOglVertex.size()) {
           if ((fOglVertex[a+2*6+0] != fOglVertex[a+5*6+0]) || //Vx for 2 and 5
               (fOglVertex[a+2*6+1] != fOglVertex[a+5*6+1]) || //Vy for 2 and 5

--- a/source/visualization/OpenGL/src/G4OpenGLStoredQtViewer.cc
+++ b/source/visualization/OpenGL/src/G4OpenGLStoredQtViewer.cc
@@ -56,7 +56,7 @@ G4OpenGLStoredQtViewer::G4OpenGLStoredQtViewer
     // Indicates that the widget has no background, i.e. when the widget receives paint events, the background is not automatically repainted. Note: Unlike WA_OpaquePaintEvent, newly exposed areas are never filled with the background (e.g., after showing a window for the first time the user can see "through" it until the application processes the paint events). This flag is set or cleared by the widget's author.
   QGLWidget::setAttribute (Qt::WA_NoSystemBackground);
 
-  setFocusPolicy(Qt::StrongFocus); // enable keybord events
+  setFocusPolicy(Qt::StrongFocus); // enable keyboard events
   fHasToRepaint = false;
   fPaintEventLock = false;
   fUpdateGLLock = false;

--- a/source/visualization/OpenGL/src/G4OpenGLStoredViewer.cc
+++ b/source/visualization/OpenGL/src/G4OpenGLStoredViewer.cc
@@ -146,7 +146,7 @@ G4bool G4OpenGLStoredViewer::CompareForKernelVisit(G4ViewParameters& lastVP) {
 
 void G4OpenGLStoredViewer::DrawDisplayLists () {
   
-  // We moved these from G4OpenGLViewer to G4ViewParamaters. To avoid
+  // We moved these from G4OpenGLViewer to G4ViewParameters. To avoid
   // editing many lines below we introduce these convenient aliases.
 #define CONVENIENT_DOUBLE_ALIAS(q) const G4double& f##q = fVP.Get##q();
 #define CONVENIENT_BOOL_ALIAS(q) const G4bool& f##q = fVP.Is##q();

--- a/source/visualization/OpenGL/src/G4OpenGLStoredXmViewer.cc
+++ b/source/visualization/OpenGL/src/G4OpenGLStoredXmViewer.cc
@@ -136,7 +136,7 @@ void G4OpenGLStoredXmViewer::DrawView () {
 
 void G4OpenGLStoredXmViewer::FinishView () {
 //  glXWaitGL (); //Wait for effects of all previous OpenGL commands to
-                //be propogated before progressing.
+                //be propagated before progressing.
 // JA: Commented out July 2021 - slows rendering down in some cases and I
 // don't see any adverse effects.
 

--- a/source/visualization/OpenGL/src/G4OpenGLViewer.cc
+++ b/source/visualization/OpenGL/src/G4OpenGLViewer.cc
@@ -1072,7 +1072,7 @@ bool G4OpenGLViewer::setExportFilename(G4String name,G4bool inc) {
   if (name.size() == 0) {
     name = getRealPrintFilename().c_str();
   } else {
-    // guess format by extention
+    // guess format by extension
     std::string extension = name.substr(name.find_last_of(".") + 1);
     // If there is a dot in the name the above might find rubbish, so...
     if (extension.size() >= 3 && extension.size() <= 4) {  // Possible extension

--- a/source/visualization/OpenGL/src/G4OpenGLXmViewer.cc
+++ b/source/visualization/OpenGL/src/G4OpenGLXmViewer.cc
@@ -71,7 +71,7 @@ void G4OpenGLXmViewer::ResetView () {
   // reset global parameters
   G4OpenGLViewer::ResetView();
 
-  //reset Xm parameteres
+  //reset Xm parameters
   zoom_high  = fVP.GetZoomFactor() * 10.0;
   zoom_low = fVP.GetZoomFactor() / 10.0;
   rot_sens_limit = 90.;

--- a/source/visualization/OpenInventor/README.OIXExtendedViewer
+++ b/source/visualization/OpenInventor/README.OIXExtendedViewer
@@ -178,7 +178,7 @@ Known problems:
    run more events.  Viewer will usually be o.k. afterwards.
 
    Unpredictable mode-switching behaviour: switching between
-   orthonormal and perspective camera may give wierd results.
+   orthonormal and perspective camera may give weird results.
    Navigation may appear "stuck" with orthonormal camera.
 
    Both the standard and extended viewers can crash the

--- a/source/visualization/OpenInventor/include/G4OpenInventorWin32.hh
+++ b/source/visualization/OpenInventor/include/G4OpenInventorWin32.hh
@@ -30,7 +30,7 @@
 #ifndef G4OPENINVENTORWIN32_HH
 #define G4OPENINVENTORWIN32_HH
 
-// For backward compatibilty.
+// For backward compatibility.
 
 #include "G4OpenInventorWin.hh"
 

--- a/source/visualization/OpenInventor/include/G4OpenInventorX.hh
+++ b/source/visualization/OpenInventor/include/G4OpenInventorX.hh
@@ -32,7 +32,7 @@
 #ifndef G4OPENINVENTORX_HH
 #define G4OPENINVENTORX_HH
 
-// For backward compatibilty.
+// For backward compatibility.
 
 #include "G4OpenInventorXt.hh"
 

--- a/source/visualization/OpenInventor/include/HEPVis/nodes/SoTrap.h
+++ b/source/visualization/OpenInventor/include/HEPVis/nodes/SoTrap.h
@@ -66,7 +66,7 @@ class SoSFNode;
  * are tapezia, and their centres are not necessarily on a line parallel to
  * the z axis.
  *
- * Note that of the 11 parameters desribed below, only 9 are really
+ * Note that of the 11 parameters described below, only 9 are really
  * independent - a check for planarity is made in the calculation of the
  * equation for each plane. If the planes are not parallel, a call to
  * G4Exception is made.

--- a/source/visualization/OpenInventor/src/G4OpenInventorQtExaminerViewer.cc
+++ b/source/visualization/OpenInventor/src/G4OpenInventorQtExaminerViewer.cc
@@ -1149,9 +1149,9 @@ void G4OpenInventorQtExaminerViewer::pickingCB(void *aThis,
             // FWJ DEBUG
             // G4cout << "FOUND trajectory LineSet" << trajectory << G4endl;
 
-       // The set of all trajectories is stored in a Seperator group node
+       // The set of all trajectories is stored in a Separator group node
        // one level above the LineSet that was picked. The nodes under that
-       // seperator are as follows (in this order): Material, LightModel,
+       // separator are as follows (in this order): Material, LightModel,
        // ResetTransform, MatrixTransform, Coordinate3, DrawStyle, LineSet
             SoSeparator * grpNode = 
                (SoSeparator*)(((SoFullPath*)path)->getNodeFromTail(1));

--- a/source/visualization/OpenInventor/src/G4OpenInventorSceneHandler.cc
+++ b/source/visualization/OpenInventor/src/G4OpenInventorSceneHandler.cc
@@ -657,7 +657,7 @@ void G4OpenInventorSceneHandler::GeneratePrerequisites()
       else detectorTreeKit->setPreview(TRUE);
 
       // Colour, etc., for SoDetectorTreeKit.  Treated differently to
-      // othere SoNodes(?).  Use fpVisAttribs stored away in
+      // other SoNodes(?).  Use fpVisAttribs stored away in
       // PreAddSolid...
       const G4VisAttributes* pApplicableVisAttribs =
 	fpViewer->GetApplicableVisAttributes (fpVisAttribs);

--- a/source/visualization/OpenInventor/src/G4OpenInventorViewer.cc
+++ b/source/visualization/OpenInventor/src/G4OpenInventorViewer.cc
@@ -92,7 +92,7 @@ G4OpenInventorViewer::G4OpenInventorViewer(
   fSoSelection->addChild(group);
 
   //  Have a camera under fSoSelection in order
-  // that the below SceneGraphSensor be notifed
+  // that the below SceneGraphSensor be notified
   // when the viewer changes the camera type.
   //  But we put the camera under a SoGroup so that
   // the SceneGraphSensor be not triggered at each change
@@ -149,7 +149,7 @@ void G4OpenInventorViewer::KernelVisitDecision () {
       //??fG4OpenInventorSceneHandler.fPODLList.size() == 0 ||
       // We need a test for empty scene graph, such as
       // staticRoot.size() or something??????????  See temporary fix
-      // in contructor.  (John Allison Aug 2001)
+      // in constructor.  (John Allison Aug 2001)
       CompareForKernelVisit(fLastVP)) {
     NeedKernelVisit ();
   }      
@@ -748,7 +748,7 @@ void G4OpenInventorViewer::SetReducedWireFrame(bool aValue) {
     break;
   }
   SetViewParameters(vp);
-  NeedKernelVisit(); // Just in case it was alread in wire framw.
+  NeedKernelVisit(); // Just in case it was already in wire frame.
   DrawDetector();
 }
 

--- a/source/visualization/OpenInventor/src/G4OpenInventorWinViewer.cc
+++ b/source/visualization/OpenInventor/src/G4OpenInventorWinViewer.cc
@@ -165,7 +165,7 @@ void G4OpenInventorWinViewer::Initialise() {
                             CW_USEDEFAULT, CW_USEDEFAULT, 
                             width,height,
                             0,menuBar,::GetModuleHandle(0),0);
-    // Retreive window and client sizez :
+    // Retrieve window and client sizez :
     RECT wrect,crect;
     GetWindowRect((HWND)fShell,&wrect);
     GetClientRect((HWND)fShell,&crect);

--- a/source/visualization/OpenInventor/src/G4OpenInventorXtExaminerViewer.cc
+++ b/source/visualization/OpenInventor/src/G4OpenInventorXtExaminerViewer.cc
@@ -1058,9 +1058,9 @@ void G4OpenInventorXtExaminerViewer::pickingCB(void *aThis,
             // The trajectory is a set of lines stored in a LineSet
             SoLineSet * trajectory = (SoLineSet *)node;
 
-       // The set of all trajectories is stored in a Seperator group node
+       // The set of all trajectories is stored in a Separator group node
        // one level above the LineSet that was picked. The nodes under that
-       // seperator are as follows (in this order): Material, LightModel,
+       // separator are as follows (in this order): Material, LightModel,
        // ResetTransform, MatrixTransform, Coordinate3, DrawStyle, LineSet
             SoSeparator * grpNode = 
                (SoSeparator*)(((SoFullPath*)path)->getNodeFromTail(1));
@@ -2883,7 +2883,7 @@ void G4OpenInventorXtExaminerViewer::lookAtSceneElementCB(Widget,
 }
 
 
-// Destroyes listsDialog and resets necessary member fields.
+// Destroys listsDialog and resets necessary member fields.
 
 void G4OpenInventorXtExaminerViewer::closeListsDialogCB(Widget, 
                                          XtPointer client_data,
@@ -3617,7 +3617,7 @@ void G4OpenInventorXtExaminerViewer::popUpFileSelDialog(Widget &dialog,
 }
 
 
-// Generic fileSelectionDialog cancelation.
+// Generic fileSelectionDialog cancellation.
 
 void G4OpenInventorXtExaminerViewer::cancelFileSelDialogCB(Widget w,
                                                            XtPointer,

--- a/source/visualization/OpenInventor/src/SoCons.cc
+++ b/source/visualization/OpenInventor/src/SoCons.cc
@@ -318,7 +318,7 @@ void SoCons::updateChildren() {
     indices[5*4*NPHI +2] = 2*NPHI+3;
     indices[5*4*NPHI +3] = 2*NPHI+2;
     indices[5*4*NPHI +4] = SO_END_FACE_INDEX;
-    // aother odd side
+    // another odd side
     indices[5*4*NPHI +5 +0] = 0;
     indices[5*4*NPHI +5 +1] = NPOINTS-2;
     indices[5*4*NPHI +5 +2] = NPOINTS-1;

--- a/source/visualization/OpenInventor/src/SoTubs.cc
+++ b/source/visualization/OpenInventor/src/SoTubs.cc
@@ -330,7 +330,7 @@ void SoTubs::updateChildren() {
     indices[5*4*NPHI +2] = 2*NPHI+3;
     indices[5*4*NPHI +3] = 2*NPHI+2;
     indices[5*4*NPHI +4] = SO_END_FACE_INDEX;
-    // aother odd side
+    // another odd side
     indices[5*4*NPHI +5 +0] = 0;
     indices[5*4*NPHI +5 +1] = NPOINTS-2;
     indices[5*4*NPHI +5 +2] = NPOINTS-1;
@@ -345,7 +345,7 @@ void SoTubs::updateChildren() {
     indices[5*4*NPHI +2] = 2*NPHI+3;
     indices[5*4*NPHI +3] = 2*NPHI+2;
     indices[5*4*NPHI +4] = SO_END_FACE_INDEX;
-    // aother odd side
+    // another odd side
     indices[5*4*NPHI +5 +0] = 0;
     indices[5*4*NPHI +5 +1] = NPOINTS-2;
     indices[5*4*NPHI +5 +2] = NPOINTS-1;
@@ -359,7 +359,7 @@ void SoTubs::updateChildren() {
     indices[5*4*NPHI +2] = SO_END_FACE_INDEX;
     indices[5*4*NPHI +3] = SO_END_FACE_INDEX;
     indices[5*4*NPHI +4] = SO_END_FACE_INDEX;
-    // aother odd side
+    // another odd side
     indices[5*4*NPHI +5 +0] = SO_END_FACE_INDEX;
     indices[5*4*NPHI +5 +1] = SO_END_FACE_INDEX;
     indices[5*4*NPHI +5 +2] = SO_END_FACE_INDEX;

--- a/source/visualization/Qt3D/src/G4Qt3DSceneHandler.cc
+++ b/source/visualization/Qt3D/src/G4Qt3DSceneHandler.cc
@@ -179,7 +179,7 @@ G4Qt3DQEntity* G4Qt3DSceneHandler::CreateNewNode()
   size_t iDepth = 1;
   while (iDepth < depth) {
     const auto& children = node->children();
-    const G4int nChildren = children.size();  // int size() (Qt covention?)
+    const G4int nChildren = children.size();  // int size() (Qt convention?)
     G4int iChild = 0;
     G4Qt3DQEntity* child = nullptr;
     for (; iChild < nChildren; ++iChild) {
@@ -833,7 +833,7 @@ void G4Qt3DSceneHandler::AddPrimitive(const G4Polyhedron& polyhedron)
       drawing_style == G4ViewParameters::hlhsr) {
 
     // Put vertices, normals into  QByteArray
-    // Accomodates both vertices and normals - hence 2*
+    // Accommodates both vertices and normals - hence 2*
     QByteArray vertexByteArray;
     const auto vertexBufferByteSize = 2*nVerts*vertexByteSize;
     vertexByteArray.resize(vertexBufferByteSize);

--- a/source/visualization/RayTracer/README
+++ b/source/visualization/RayTracer/README
@@ -64,7 +64,7 @@ d) /vis/rayTracer/column nColumn
     in default 640 pixels
 
 e) /vis/rayTracer/row nRow
-    number of virtical pixels
+    number of vertical pixels
     in default 640 pixels
 
 f) /vis/rayTracer/span angle unit

--- a/source/visualization/RayTracer/include/G4RTSimpleScanner.hh
+++ b/source/visualization/RayTracer/include/G4RTSimpleScanner.hh
@@ -55,7 +55,7 @@ public: // with description
   // commands.
 
   virtual void Initialize(G4int nRow, G4int nColumn);
-  // Intialises scanner for window with nRow rows and nColumn columns.
+  // Initialises scanner for window with nRow rows and nColumn columns.
 
   virtual G4bool Coords(G4int& iRow, G4int& iColumn);
   // Supplies coordinate (iRow,iColumn) and returns false when the

--- a/source/visualization/RayTracer/include/G4RTXScanner.hh
+++ b/source/visualization/RayTracer/include/G4RTXScanner.hh
@@ -61,7 +61,7 @@ public: // with description
   // commands.
 
   virtual void Initialize(G4int nRow, G4int nColumn);
-  // Intialises scanner for window with nRow rows and nColumn columns.
+  // Initialises scanner for window with nRow rows and nColumn columns.
 
   virtual G4bool Coords(G4int& iRow, G4int& iColumn);
   // Supplies coordinate (iRow,iColumn) and returns false when the

--- a/source/visualization/RayTracer/include/G4TheMTRayTracer.hh
+++ b/source/visualization/RayTracer/include/G4TheMTRayTracer.hh
@@ -98,7 +98,7 @@ class G4TheMTRayTracer : public G4TheRayTracer
   public: // with description
     virtual void Trace(const G4String& fileName);
     // The main entry point which triggers ray tracing. "fileName" is output
-    // file name, and it must contain extention (e.g. myFigure.jpg). This
+    // file name, and it must contain extension (e.g. myFigure.jpg). This
     // method is available only if Geant4 is at Idle state.
 
   protected:

--- a/source/visualization/RayTracer/include/G4TheRayTracer.hh
+++ b/source/visualization/RayTracer/include/G4TheRayTracer.hh
@@ -88,7 +88,7 @@ class G4TheRayTracer
   public: // with description
     virtual void Trace(const G4String& fileName);
     // The main entry point which triggers ray tracing. "fileName" is output
-    // file name, and it must contain extention (e.g. myFigure.jpg). This
+    // file name, and it must contain extension (e.g. myFigure.jpg). This
     // method is available only if Geant4 is at Idle state.
 
   protected:
@@ -97,7 +97,7 @@ class G4TheRayTracer
     void CreateFigureFile(const G4String& fileName);
     // Create figure file after an event loop
     G4bool GenerateColour(G4Event* anEvent);
-    // Calcurate RGB for one trajectory
+    // Calculate RGB for one trajectory
     virtual void StoreUserActions();
     virtual void RestoreUserActions();
     // Store and restore user action classes if defined

--- a/source/visualization/RayTracer/include/G4VRTScanner.hh
+++ b/source/visualization/RayTracer/include/G4VRTScanner.hh
@@ -53,7 +53,7 @@ public: // with description
   // commands.
 
   virtual void Initialize(G4int nRow, G4int nColumn) = 0;
-  // Intialises scanner for window with nRow rows and nColumn columns.
+  // Initialises scanner for window with nRow rows and nColumn columns.
 
   virtual G4bool Coords(G4int& iRow, G4int& iColumn) = 0;
   // Supplies coordinate (iRow,iColumn) and returns false when the

--- a/source/visualization/RayTracer/src/G4TheMTRayTracer.cc
+++ b/source/visualization/RayTracer/src/G4TheMTRayTracer.cc
@@ -184,7 +184,7 @@ G4bool G4TheMTRayTracer::CreateBitMap()
   // Event loop
   G4int nEvent = nRow*nColumn;
 ////  mrm->BeamOn(nEvent);
-////  Temporary work-around until direct invokation of G4RunManager::BeamOn() works.
+////  Temporary work-around until direct invocation of G4RunManager::BeamOn() works.
   G4String str = "/run/beamOn " + G4UIcommand::ConvertToString(nEvent);
   G4UImanager::GetUIpointer()->ApplyCommand(str);
 

--- a/source/visualization/Vtk/src/G4VtkSceneHandler.cc
+++ b/source/visualization/Vtk/src/G4VtkSceneHandler.cc
@@ -789,7 +789,7 @@ void G4VtkSceneHandler::AddCompound(const G4Mesh& mesh)
   // Instantiate a temporary G4PhysicalVolumeModel
   G4ModelingParameters tmpMP;
   tmpMP.SetCulling(false);            // This avoids drawing transparent...
-  tmpMP.SetCullingInvisible(false);   // ... or invisble volumes.
+  tmpMP.SetCullingInvisible(false);   // ... or invisible volumes.
   const G4bool useFullExtent = false;  // To avoid calculating the extent
 
   G4PhysicalVolumeModel tmpPVModel(container, G4PhysicalVolumeModel::UNLIMITED,

--- a/source/visualization/Vtk/src/G4VtkViewer.cc
+++ b/source/visualization/Vtk/src/G4VtkViewer.cc
@@ -89,7 +89,7 @@ void G4VtkViewer::Initialise()
   _renderWindow->SetPosition(positionX, positionY);
 #ifdef __APPLE__
   // Adjust window size for Apple to make it correspond to OpenGL.
-  // Maybe it's OpenGL that shoud be adjusted.
+  // Maybe it's OpenGL that should be adjusted.
   const G4double pixelFactor = 2.;
 #else
   const G4double pixelFactor = 1.;

--- a/source/visualization/externals/gl2ps/include/G4OpenGL2PSAction.hh
+++ b/source/visualization/externals/gl2ps/include/G4OpenGL2PSAction.hh
@@ -39,10 +39,10 @@ public:
  void setFileName(const char*);
  void setExportImageFormat(unsigned int);
  bool enableFileWriting();
-  // return true if ok, false is an error occured
+  // return true if ok, false if an error occurred
 
  bool disableFileWriting();
-  // return true when OK, false if errror
+  // return true when OK, false if error
 
  bool fileWritingEnabled() const;
  void setLineWidth(int);

--- a/source/visualization/externals/gl2ps/src/gl2ps.cc
+++ b/source/visualization/externals/gl2ps/src/gl2ps.cc
@@ -2573,7 +2573,7 @@ static void gl2psPrintPostScriptPixmap(GLfloat x, GLfloat y, GL2PSimage *im)
   /* FIXME: should we define an option for these? Or just keep the
      8-bit per component case? */
   int greyscale = 0; /* set to 1 to output greyscale image */
-  int nbit = 8; /* number of bits per color compoment (2, 4 or 8) */
+  int nbit = 8; /* number of bits per color component (2, 4 or 8) */
 
   if((width <= 0) || (height <= 0)) return;
 
@@ -3915,7 +3915,7 @@ static void gl2psPDFgroupListWriteMainStream(void)
                         prim->verts[0].xyz[0], prim->verts[0].xyz[1]);
         }
         else{
-          /* the two segements are connected, so we just append to the
+          /* the two segments are connected, so we just append to the
              current path */
           gl2ps->streamlength +=
             gl2psPrintf("%f %f l\n",

--- a/source/visualization/gMocren/include/G4GMocrenFileCTtoDensityMap.hh
+++ b/source/visualization/gMocren/include/G4GMocrenFileCTtoDensityMap.hh
@@ -53,7 +53,7 @@ protected:
   G4int kSize;
 
 private:
-  // Private copy constructor and assigment operator - copying and
+  // Private copy constructor and assignment operator - copying and
   // assignment not allowed.  Keeps Coverity happy.
   G4GMocrenFileCTtoDensityMap (const G4GMocrenFileCTtoDensityMap&);
   G4GMocrenFileCTtoDensityMap& operator = (const G4GMocrenFileCTtoDensityMap&);

--- a/source/visualization/gMocren/include/G4GMocrenFileSceneHandler.hh
+++ b/source/visualization/gMocren/include/G4GMocrenFileSceneHandler.hh
@@ -169,7 +169,7 @@ private:
     G4bool operator < (const Index3D & _right) const;
     G4bool operator == (const Index3D & _right) const;
   private:
-    // Private assigment operator -
+    // Private assignment operator -
     // assignment not allowed.  Keeps Coverity happy.
     // Index3D& operator = (const Index3D&);
   };

--- a/source/visualization/gMocren/include/G4GMocrenIO.hh
+++ b/source/visualization/gMocren/include/G4GMocrenIO.hh
@@ -24,7 +24,7 @@
 // ********************************************************************
 //
 //
-// File I/O manager class for writing or reading calcuated dose
+// File I/O manager class for writing or reading calculated dose
 // distribution and some event information
 //
 //
@@ -338,7 +338,7 @@ public:
 
   //----- Dose distribution -----//
 
-  // instanciate a dose distribution data object
+  // instantiate a dose distribution data object
   void newDoseDist();
   // get number of dose distribion data
   int getNumDoseDist();
@@ -364,7 +364,7 @@ public:
   // set the dose distribution 
   void setDoseDist(double * _image, int _num = 0);
   double * getDoseDist(int _z, int _num = 0);
-  // add another dose ditribution map to this map
+  // add another dose distribution map to this map
   bool addDoseDist(std::vector<double *> & _image, int _num = 0);
 
   // get & get center position of calculated dose region
@@ -385,13 +385,13 @@ public:
 protected:
   // check whether dose variable is empty or not
   bool isDoseEmpty();
-  // calcuated scale value to convert dose distribution into image
+  // calculated scale value to convert dose distribution into image
   void calcDoseDistScale();
 
 public:
   //----- RoI -----//
 
-  // instanciate an RoI data object
+  // instantiate an RoI data object
   void newROI();
   // get number of RoI data
   int getNumROI();

--- a/source/visualization/gMocren/src/G4GMocrenFileSceneHandler.cc
+++ b/source/visualization/gMocren/src/G4GMocrenFileSceneHandler.cc
@@ -322,7 +322,7 @@ void	G4GMocrenFileSceneHandler::BeginSavingGdd( void )
       kgMocrenIO->setModalityImageDensityMap(map);
       
     } else {
-      G4cout << "cann't open the file : " << fname << G4endl;
+      G4cout << "can't open the file : " << fname << G4endl;
     }
     */
 

--- a/source/visualization/gMocren/src/G4GMocrenIO.cc
+++ b/source/visualization/gMocren/src/G4GMocrenIO.cc
@@ -26,7 +26,7 @@
 //
 //
 //
-// File I/O manager class for writing or reading calcuated dose
+// File I/O manager class for writing or reading calculated dose
 // distribution and some event information
 //
 // Created:  Mar. 31, 2009  Akinori Kimura : release for the gMocrenFile driver
@@ -703,7 +703,7 @@ bool G4GMocrenIO::storeData4() {
     calcDoseDistScale();
 
     for(int ndose = 0; ndose < nDoseDist; ndose++) {
-      // dose distrbution image size
+      // dose distribution image size
       kDose[ndose].getSize(size);
       if(kLittleEndianOutput) {
 	ofile.write((char *)size, 3*sizeof(int));
@@ -1171,7 +1171,7 @@ bool G4GMocrenIO::storeData3() {
     calcDoseDistScale();
 
     for(int ndose = 0; ndose < nDoseDist; ndose++) {
-      // dose distrbution image size
+      // dose distribution image size
       kDose[ndose].getSize(size);
       ofile.write((char *)size, 3*sizeof(int));
       if(DEBUG || kVerbose > 0) {
@@ -1459,7 +1459,7 @@ bool G4GMocrenIO::storeData2() {
   if(!isDoseEmpty()) {
     calcDoseDistScale();
 
-    // dose distrbution image size
+    // dose distribution image size
     kDose[0].getSize(size);
     ofile.write((char *)size, 3*sizeof(int));
     if(DEBUG || kVerbose > 0) {
@@ -1878,7 +1878,7 @@ bool G4GMocrenIO::retrieveData4() {
 
     newDoseDist();
 
-    // dose distrbution image size
+    // dose distribution image size
     ifile.read((char *)ctmp, 3*sizeof(int));
     convertEndian(ctmp, size[0]);
     convertEndian(ctmp+sizeof(int), size[1]);
@@ -2399,7 +2399,7 @@ bool G4GMocrenIO::retrieveData3() {
 
     newDoseDist();
 
-    // dose distrbution image size
+    // dose distribution image size
     ifile.read((char *)ctmp, 3*sizeof(int));
     convertEndian(ctmp, size[0]);
     convertEndian(ctmp+sizeof(int), size[1]);
@@ -2817,7 +2817,7 @@ bool G4GMocrenIO::retrieveData2() {
 
     newDoseDist();
 
-    // dose distrbution image size
+    // dose distribution image size
     ifile.read((char *)ctmp, 3*sizeof(int));
     convertEndian(ctmp, size[0]);
     convertEndian(ctmp+sizeof(int), size[1]);

--- a/source/visualization/gMocren/src/G4GMocrenMessenger.cc
+++ b/source/visualization/gMocren/src/G4GMocrenMessenger.cc
@@ -268,7 +268,7 @@ std::vector<G4String> G4GMocrenMessenger::getHitScorerNames() {
 }
 
 void G4GMocrenMessenger::list() {
-  G4cout << "  Current valuess of gMocren command parameters:" << G4endl;
+  G4cout << "  Current values of gMocren command parameters:" << G4endl;
   //
   G4cout << "    volume name:        " << kgMocrenVolumeName << G4endl;
   //

--- a/source/visualization/management/Doxyfile
+++ b/source/visualization/management/Doxyfile
@@ -721,7 +721,7 @@ COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
 
 # Load stylesheet definitions from file. Syntax is similar to doxygen's 
-# config file, i.e. a series of assigments. You only have to provide 
+# config file, i.e. a series of assignments. You only have to provide 
 # replacements, missing definitions are set to their default value.
 
 RTF_STYLESHEET_FILE    = 
@@ -899,7 +899,7 @@ EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 
 #---------------------------------------------------------------------------
-# Configuration::addtions related to external references   
+# Configuration::additions related to external references   
 #---------------------------------------------------------------------------
 
 # The TAGFILES option can be used to specify one or more tagfiles. 
@@ -981,7 +981,7 @@ CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
 
 # If the UML_LOOK tag is set to YES doxygen will generate inheritance and 
-# collaboration diagrams in a style similiar to the OMG's Unified Modeling 
+# collaboration diagrams in a style similar to the OMG's Unified Modeling 
 # Language.
 
 UML_LOOK               = NO
@@ -1075,7 +1075,7 @@ GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES
 
 #---------------------------------------------------------------------------
-# Configuration::addtions related to the search engine   
+# Configuration::additions related to the search engine   
 #---------------------------------------------------------------------------
 
 # The SEARCHENGINE tag specifies whether or not a search engine should be 

--- a/source/visualization/management/include/G4VSceneHandler.hh
+++ b/source/visualization/management/include/G4VSceneHandler.hh
@@ -401,7 +401,7 @@ protected:
   void StandardSpecialMeshRendering(const G4Mesh&);
   // Standard way of special mesh rendering.
   // MySceneHandler::AddCompound(const G4Mesh& mesh) may use this if
-  // appropriate or implement its own special mesh rendereing.
+  // appropriate or implement its own special mesh rendering.
 
   void Draw3DRectMeshAsDots(const G4Mesh&);
   // For a rectangular 3-D mesh, draw as coloured dots by colour and material,

--- a/source/visualization/management/include/G4VViewer.hh
+++ b/source/visualization/management/include/G4VViewer.hh
@@ -53,12 +53,12 @@ public: // With description
 
   virtual void Initialise ();
   // Called immediately after construction for those operations that
-  // must await complete contruction of viewer and all its bases.  For
+  // must await complete construction of viewer and all its bases.  For
   // example, if this class (G4VViewer) is inherited virtually, as in
   // the OpenGL sub-category, it will not be fully constructed until
   // *after* the the derived viewer (this is the rule about order of
   // construction for virtual inheritance), so the derived viewer may
-  // not use information in G4VViewer in its contructor.  Hence such
+  // not use information in G4VViewer in its constructor.  Hence such
   // code must be in Initialise().
 
   //////////////////////////////////////////////////////////////

--- a/source/visualization/management/include/G4ViewParameters.hh
+++ b/source/visualization/management/include/G4ViewParameters.hh
@@ -368,7 +368,7 @@ private:
   G4double     fDolly;           // Distance towards current target point.
   G4bool       fLightsMoveWithCamera;
   G4Vector3D   fRelativeLightpointDirection;
-  // i.e., rel. to object or camera accoding to G4bool fLightsMoveWithCamera.
+  // i.e., rel. to object or camera according to G4bool fLightsMoveWithCamera.
   G4Vector3D   fActualLightpointDirection;
   G4VisAttributes fDefaultVisAttributes;
   G4VisAttributes fDefaultTextVisAttributes;

--- a/source/visualization/management/include/G4VisExecutive.hh
+++ b/source/visualization/management/include/G4VisExecutive.hh
@@ -78,7 +78,7 @@
 //     with a verbosity string. e.g:
 //       G4VisManager* visManager = new G4VisExecutive("quiet");
 // (c) You can register your own graphics system like this.
-// (d) Your can intialise like this with C++ code or use /vis/initialize.
+// (d) Your can initialise like this with C++ code or use /vis/initialize.
 //
 // If you need to perform the instantiation and the initialisation in
 // separate files, e.g., to establish the verbosity before

--- a/source/visualization/management/include/G4VisManager.hh
+++ b/source/visualization/management/include/G4VisManager.hh
@@ -157,7 +157,7 @@ public: // With description
 
 private:
 
-  // Private copy constructor and assigment operator - copying and
+  // Private copy constructor and assignment operator - copying and
   // assignment not allowed.  Keeps CodeWizard happy.
   G4VisManager (const G4VisManager&);
   G4VisManager& operator = (const G4VisManager&);
@@ -310,7 +310,7 @@ public: // With description
   // Used by run manager to notify change.
 
   void IgnoreStateChanges(G4bool);
-  // This method shoud be invoked by a class that has its own event loop,
+  // This method should be invoked by a class that has its own event loop,
   // such as the RayTracer, material scanner, etc. If the argument is true,
   // the following state changes among Idle, GeomClosed and EventProc are
   // caused by such a class, and thus not by the ordinary event simulation.

--- a/source/visualization/management/include/G4VisModelManager.hh
+++ b/source/visualization/management/include/G4VisModelManager.hh
@@ -70,7 +70,7 @@ public: // With description
 
 private:
 
-  // Private copy constructor and assigment operator - copying and
+  // Private copy constructor and assignment operator - copying and
   // assignment not allowed.  Keeps Coverity happy.
   G4VisModelManager (const G4VisModelManager&);
   G4VisModelManager& operator = (const G4VisModelManager&);

--- a/source/visualization/management/src/G4Scene.cc
+++ b/source/visualization/management/src/G4Scene.cc
@@ -296,7 +296,7 @@ G4bool G4Scene::operator != (const G4Scene& scene) const {
   /* A complete comparison should, perhaps, include a comparison of
      individual models, but it is not easy to implement operator!= for
      all models.  Also, it would be unfeasible to ask users to
-     implement opeerator!= if we ever get round to allowing
+     implement operator!= if we ever get round to allowing
      user-defined models.  Moreover, there is no editing of G4Scene
      objects, apart from changing fRefreshAtEndOfEvent, etc; as far as
      models are concerned, all you can ever do is add them, so a test

--- a/source/visualization/management/src/G4VSceneHandler.cc
+++ b/source/visualization/management/src/G4VSceneHandler.cc
@@ -1026,7 +1026,7 @@ G4double G4VSceneHandler::GetLineWidth(const G4VisAttributes* pVisAttribs)
 G4ViewParameters::DrawingStyle G4VSceneHandler::GetDrawingStyle
 (const G4VisAttributes* pVisAttribs) {
   // Drawing style is normally determined by the view parameters, but
-  // it can be overriddden by the ForceDrawingStyle flag in the vis
+  // it can be overridden by the ForceDrawingStyle flag in the vis
   // attributes.
   const G4ViewParameters& vp = fpViewer->GetViewParameters();
   const G4ViewParameters::DrawingStyle viewerStyle = vp.GetDrawingStyle();
@@ -1059,7 +1059,7 @@ G4ViewParameters::DrawingStyle G4VSceneHandler::GetDrawingStyle
       case (G4VisAttributes::wireframe):
       default:
         // But if forced style is wireframe, do it, because one of its
-        // main uses is in displaying the consituent solids of a Boolean
+        // main uses is in displaying the constituent solids of a Boolean
         // solid and their surfaces overlap with the resulting Booean
         // solid, making a mess if hlr is specified.
         resultantStyle = G4ViewParameters::wireframe;
@@ -1118,7 +1118,7 @@ G4double G4VSceneHandler::GetMarkerSize
 G4int G4VSceneHandler::GetNoOfSides(const G4VisAttributes* pVisAttribs)
 {
   // No. of sides (lines segments per circle) is normally determined
-  // by the view parameters, but it can be overriddden by the
+  // by the view parameters, but it can be overridden by the
   // ForceLineSegmentsPerCircle in the vis attributes.
   G4int lineSegmentsPerCircle = fpViewer->GetViewParameters().GetNoOfSides();
   if (pVisAttribs) {
@@ -1205,7 +1205,7 @@ void G4VSceneHandler::PseudoSceneForTetVertices::AddSolid(const G4VSolid& solid)
 void G4VSceneHandler::StandardSpecialMeshRendering(const G4Mesh& mesh)
 // Standard way of special mesh rendering.
 // MySceneHandler::AddCompound(const G4Mesh& mesh) may use this if
-// appropriate or implement its own special mesh rendereing.
+// appropriate or implement its own special mesh rendering.
 {
   G4bool implemented = false;
   switch (mesh.GetMeshType()) {
@@ -1281,7 +1281,7 @@ void G4VSceneHandler::Draw3DRectMeshAsDots(const G4Mesh& mesh)
     // Instantiate a temporary G4PhysicalVolumeModel
     G4ModelingParameters tmpMP;
     tmpMP.SetCulling(true);  // This avoids drawing transparent...
-    tmpMP.SetCullingInvisible(true);  // ... or invisble volumes.
+    tmpMP.SetCullingInvisible(true);  // ... or invisible volumes.
     const G4bool useFullExtent = true;  // To avoid calculating the extent
     G4PhysicalVolumeModel tmpPVModel
     (container,
@@ -1428,7 +1428,7 @@ void G4VSceneHandler::Draw3DRectMeshAsSurfaces(const G4Mesh& mesh)
     // Instantiate a temporary G4PhysicalVolumeModel
     G4ModelingParameters tmpMP;
     tmpMP.SetCulling(true);  // This avoids drawing transparent...
-    tmpMP.SetCullingInvisible(true);  // ... or invisble volumes.
+    tmpMP.SetCullingInvisible(true);  // ... or invisible volumes.
     const G4bool useFullExtent = true;  // To avoid calculating the extent
     G4PhysicalVolumeModel tmpPVModel
     (container,
@@ -1572,7 +1572,7 @@ void G4VSceneHandler::DrawTetMeshAsDots(const G4Mesh& mesh)
     // Instantiate a temporary G4PhysicalVolumeModel
     G4ModelingParameters tmpMP;
     tmpMP.SetCulling(true);  // This avoids drawing transparent...
-    tmpMP.SetCullingInvisible(true);  // ... or invisble volumes.
+    tmpMP.SetCullingInvisible(true);  // ... or invisible volumes.
     const G4bool useFullExtent = true;  // To avoid calculating the extent
     G4PhysicalVolumeModel tmpPVModel
     (container,
@@ -1733,7 +1733,7 @@ void G4VSceneHandler::DrawTetMeshAsSurfaces(const G4Mesh& mesh)
     // Instantiate a temporary G4PhysicalVolumeModel
     G4ModelingParameters tmpMP;
     tmpMP.SetCulling(true);  // This avoids drawing transparent...
-    tmpMP.SetCullingInvisible(true);  // ... or invisble volumes.
+    tmpMP.SetCullingInvisible(true);  // ... or invisible volumes.
     const G4bool useFullExtent = true;  // To avoid calculating the extent
     G4PhysicalVolumeModel tmpPVModel
     (container,

--- a/source/visualization/management/src/G4VVisCommand.cc
+++ b/source/visualization/management/src/G4VVisCommand.cc
@@ -227,7 +227,7 @@ void G4VVisCommand::CheckSceneAndNotifyHandlers(G4Scene* pScene)
     return;
   }
 
-  // Scene has changed.  If it is the scene of the currrent scene handler
+  // Scene has changed.  If it is the scene of the current scene handler
   // refresh viewers of all scene handlers using this scene. If not, it may be
   // a scene that the user is building up before attaching to a scene handler,
   // so do nothing.

--- a/source/visualization/management/src/G4VisCommandsSceneAdd.cc
+++ b/source/visualization/management/src/G4VisCommandsSceneAdd.cc
@@ -1514,7 +1514,7 @@ void G4VisCommandSceneAddLogicalVolume::SetNewValue (G4UIcommand*,
       if (axes) {
         if (axesSuccessful) {
           G4cout <<
-          "\n  Axes have also been added at the origin of local cooordinates.";
+          "\n  Axes have also been added at the origin of local coordinates.";
         } else {
           G4cout <<
           "\n  Axes have not been added for some reason possibly stated above.";

--- a/source/visualization/management/src/G4VisCommandsViewer.cc
+++ b/source/visualization/management/src/G4VisCommandsViewer.cc
@@ -925,7 +925,7 @@ G4VisCommandViewerCreate::G4VisCommandViewerCreate (): fId (0) {
   fpCommand -> SetGuidance
   ("- single number, e.g., \"600\": square window;");
   fpCommand -> SetGuidance
-  ("- two numbers, e.g., \"800x600\": rectangluar window;");
+  ("- two numbers, e.g., \"800x600\": rectanguluar window;");
   fpCommand -> SetGuidance
   ("- two numbers plus placement hint, e.g., \"600x600-100+100\" places window of size"
    "\n  600x600 100 pixels left and 100 pixels down from top right corner.");
@@ -1089,7 +1089,7 @@ void G4VisCommandViewerCreate::SetNewValue (G4UIcommand* command, G4String newVa
       // Copy view parameters from existing viewer, except for...
       fExistingVP.SetAutoRefresh(vp.IsAutoRefresh());
       fExistingVP.SetBackgroundColour(vp.GetBackgroundColour());
-      // ...including window hint paramaters that have been set already above...
+      // ...including window hint parameters that have been set already above...
       fExistingVP.SetXGeometryString(vp.GetXGeometryString());
       vp = fExistingVP;
       newViewer->SetViewParameters(vp);

--- a/source/visualization/management/src/G4VisManager.cc
+++ b/source/visualization/management/src/G4VisManager.cc
@@ -1558,7 +1558,7 @@ void G4VisManager::RegisterEndOfRunUserVisAction
 void G4VisManager::SetCurrentScene (G4Scene* pScene) {
   if (pScene != fpScene) {
     // A change of scene.  Therefore reset transients drawn flags.  All
-    // memory of previous transient proceessing thereby erased...
+    // memory of previous transient processing thereby erased...
     ResetTransientsDrawnFlags();
   }
   fpScene = pScene;

--- a/source/visualization/modeling/README
+++ b/source/visualization/modeling/README
@@ -1,6 +1,6 @@
 Modeling
 =======
 
-The idea is to put GEANT4-aware but user-enviroment-independent code
+The idea is to put GEANT4-aware but user-environment-independent code
 here.  It introduces the concept of a G4VModel.
 

--- a/source/visualization/modeling/include/G4ArrowModel.hh
+++ b/source/visualization/modeling/include/G4ArrowModel.hh
@@ -62,7 +62,7 @@ public: // With description
 
 private:
 
-  // Private copy contructor and assignment to forbid use...
+  // Private copy constructor and assignment to forbid use...
   G4ArrowModel (const G4ArrowModel&);
   G4ArrowModel& operator = (const G4ArrowModel&);
 

--- a/source/visualization/modeling/include/G4AxesModel.hh
+++ b/source/visualization/modeling/include/G4AxesModel.hh
@@ -76,7 +76,7 @@ public: // With description
 
 private:
 
-  // Private copy contructor and assignment to forbid use...
+  // Private copy constructor and assignment to forbid use...
   G4AxesModel (const G4AxesModel&);
   G4AxesModel& operator = (const G4AxesModel&);
 

--- a/source/visualization/modeling/include/G4CallbackModel.hh
+++ b/source/visualization/modeling/include/G4CallbackModel.hh
@@ -68,7 +68,7 @@ protected:
 
 private:
 
-  // Private copy constructor and assigment operator - copying and
+  // Private copy constructor and assignment operator - copying and
   // assignment not allowed.  Keeps CodeWizard happy.
   G4CallbackModel (const G4CallbackModel&);
   G4CallbackModel& operator = (const G4CallbackModel&);

--- a/source/visualization/modeling/include/G4ElectricFieldModel.hh
+++ b/source/visualization/modeling/include/G4ElectricFieldModel.hh
@@ -64,7 +64,7 @@ protected:
   // If (field==0), the function should do nothing; returning without error.
 
 private:
-  // Private copy contructor and assignment to forbid use...
+  // Private copy constructor and assignment to forbid use...
   G4ElectricFieldModel(const G4ElectricFieldModel&);
   G4ElectricFieldModel& operator=(const G4ElectricFieldModel&);
 };

--- a/source/visualization/modeling/include/G4GPSModel.hh
+++ b/source/visualization/modeling/include/G4GPSModel.hh
@@ -67,7 +67,7 @@ protected:
   G4Colour fColour;
 
 private:
-  // Private copy constructor and assigment operator - copying and
+  // Private copy constructor and assignment operator - copying and
   // assignment not allowed.  Keeps CodeWizard happy.
   G4GPSModel (const G4GPSModel&);
   G4GPSModel& operator = (const G4GPSModel&);

--- a/source/visualization/modeling/include/G4MagneticFieldModel.hh
+++ b/source/visualization/modeling/include/G4MagneticFieldModel.hh
@@ -65,7 +65,7 @@ protected:
   // If (field==0), the function should do nothing; returning without error.
 
 private:
-  // Private copy contructor and assignment to forbid use...
+  // Private copy constructor and assignment to forbid use...
   G4MagneticFieldModel(const G4MagneticFieldModel&);
   G4MagneticFieldModel& operator=(const G4MagneticFieldModel&);
 };

--- a/source/visualization/modeling/include/G4ModelingParameters.hh
+++ b/source/visualization/modeling/include/G4ModelingParameters.hh
@@ -63,7 +63,7 @@ public: // With description
   };
 
   // enums and nested class for communicating a modification to the vis
-  // attributes for a specfic touchable defined by PVNameCopyNoPath.
+  // attributes for a specific touchable defined by PVNameCopyNoPath.
   enum VisAttributesSignifier {
     VASVisibility,
     VASDaughtersInvisible,

--- a/source/visualization/modeling/include/G4PhysicalVolumeMassScene.hh
+++ b/source/visualization/modeling/include/G4PhysicalVolumeMassScene.hh
@@ -39,7 +39,7 @@
 //
 // The calculation is quite tricky, since it involves subtracting the
 // mass of that part of the mother that is occupied by each daughter and
-// then adding the mass of the daughter, and so on down the heirarchy.
+// then adding the mass of the daughter, and so on down the hierarchy.
 //
 // Usage for a given G4PhysicalVolumeModel* pvModel:
 //   G4PhysicalVolumeMassScene massScene(pvModel);

--- a/source/visualization/modeling/include/G4PhysicalVolumeModel.hh
+++ b/source/visualization/modeling/include/G4PhysicalVolumeModel.hh
@@ -307,7 +307,7 @@ protected:
 
 private:
 
-  // Private copy constructor and assigment operator - copying and
+  // Private copy constructor and assignment operator - copying and
   // assignment not allowed.  Keeps CodeWizard happy.
   G4PhysicalVolumeModel (const G4PhysicalVolumeModel&);
   G4PhysicalVolumeModel& operator = (const G4PhysicalVolumeModel&);

--- a/source/visualization/modeling/include/G4TextModel.hh
+++ b/source/visualization/modeling/include/G4TextModel.hh
@@ -55,7 +55,7 @@ public: // With description
 
 private:
 
-  // Private copy contructor and assignment to forbid use...
+  // Private copy constructor and assignment to forbid use...
   G4TextModel (const G4TextModel&);
   G4TextModel& operator = (const G4TextModel&);
 

--- a/source/visualization/modeling/include/G4VFieldModel.hh
+++ b/source/visualization/modeling/include/G4VFieldModel.hh
@@ -65,7 +65,7 @@ public: // With description
   virtual void DescribeYourselfTo(G4VGraphicsScene& sceneHandler);
   // The main task of a model is to describe itself to the graphics scene.
   // Note: It is in this function that the extent for drawing the filed must
-  // be calcualted. If fExtentForField is null, pick up the extent from
+  // be calculated. If fExtentForField is null, pick up the extent from
   // the sceneHandler.
 
 protected:
@@ -79,7 +79,7 @@ protected:
 
 private:
 
-  // Private copy contructor and assignment to forbid use...
+  // Private copy constructor and assignment to forbid use...
   G4VFieldModel(const G4VFieldModel&);
   G4VFieldModel& operator=(const G4VFieldModel&);
 

--- a/source/visualization/modeling/include/G4VModel.hh
+++ b/source/visualization/modeling/include/G4VModel.hh
@@ -32,7 +32,7 @@
 //
 // G4VModel is a base class for visualization models.  A model is a
 // graphics-system-indepedent description of a Geant4 component.
-// The key fuctionality of a model is to know how to describe itself
+// The key functionality of a model is to know how to describe itself
 // to a scene handler.  A scene is a collection of models.
 // A special case is made for G4PhysicalVolumeModel - a non-null pointer
 // is to be returned by G4PhysicalVolumeModel::GetG4PhysicalVolumeModel().
@@ -103,7 +103,7 @@ protected:
 
 private:
 
-  // Private copy constructor and assigment operator - copying and
+  // Private copy constructor and assignment operator - copying and
   // assignment not allowed.  Keeps CodeWizard happy.
   G4VModel (const G4VModel&);
   G4VModel& operator = (const G4VModel&);

--- a/source/visualization/modeling/include/G4VTrajectoryModel.hh
+++ b/source/visualization/modeling/include/G4VTrajectoryModel.hh
@@ -67,7 +67,7 @@ public:
 
 private:
 
-  // Private copy constructor and assigment operator - copying and
+  // Private copy constructor and assignment operator - copying and
   // assignment not allowed.  Keeps Coverity happy.
   G4VTrajectoryModel (const G4VTrajectoryModel&);
   G4VTrajectoryModel& operator = (const G4VTrajectoryModel&);

--- a/source/visualization/modeling/include/G4VisTrajContext.icc
+++ b/source/visualization/modeling/include/G4VisTrajContext.icc
@@ -105,7 +105,7 @@ inline void G4VisTrajContext::Print(std::ostream& ostr) const
   ostr<<"Name:                       "<<Name()<<G4endl;
   ostr<<"Line colour                 "<<GetLineColour()<<G4endl;
   ostr<<"Draw line ?                 "<<GetDrawLine()<<G4endl;
-  ostr<<"Line visibile ?             "<<GetLineVisible()<<G4endl;
+  ostr<<"Line visible ?              "<<GetLineVisible()<<G4endl;
   ostr<<"Draw auxiliary points ?     "<<GetDrawAuxPts()<<G4endl;
   ostr<<"Auxiliary points type       "<<GetAuxPtsType()<<G4endl;
   ostr<<"Auxiliary points size       "<<GetAuxPtsSize()<<G4endl;

--- a/source/visualization/modeling/src/G4LogicalVolumeModel.cc
+++ b/source/visualization/modeling/src/G4LogicalVolumeModel.cc
@@ -59,11 +59,11 @@ G4LogicalVolumeModel::G4LogicalVolumeModel
   // represent this logical volume.  It has no rotation and a null
   // translation so that the logical volume will be seen in its own
   // reference system.  It will be added to the physical volume store
-  // but it will not be part of the normal geometry heirarchy so it
+  // but it will not be part of the normal geometry hierarchy so it
   // has no mother.
   G4PhysicalVolumeModel
 (new G4PVPlacement (0,                   // No rotation.
-		    G4ThreeVector(),     // Null traslation.
+		    G4ThreeVector(),     // Null translation.
 		    "PhysVol representation of LogVol " + pLV -> GetName (),
 		    pLV,
 		    0,                   // No mother.

--- a/source/visualization/modeling/src/G4Mesh.cc
+++ b/source/visualization/modeling/src/G4Mesh.cc
@@ -43,7 +43,7 @@
 //    /vis/viewer/set/specialMeshRendering
 //    /vis/viewer/set/specialMeshRenderingOption
 //    /vis/viewer/set/specialMeshVolumes
-// See guidance on the above commmands for more detail.
+// See guidance on the above commands for more detail.
 //
 // Note that if no special mesh volumes are specified,
 // G4PhysicalVolumeModel will test all volumes, and therefore

--- a/source/visualization/modeling/src/G4PhysicalVolumeModel.cc
+++ b/source/visualization/modeling/src/G4PhysicalVolumeModel.cc
@@ -89,8 +89,8 @@ G4PhysicalVolumeModel::G4PhysicalVolumeModel
   if (!fpTopPV) {
 
     // In some circumstances creating an "empty" G4PhysicalVolumeModel is
-    // allowed, so I have supressed the G4Exception below.  If it proves to
-    // be a problem we might have to re-instate it, but it is unlikley to
+    // allowed, so I have suppressed the G4Exception below.  If it proves to
+    // be a problem we might have to re-instate it, but it is unlikely to
     // be used except by visualisation experts.  See, for example, /vis/list,
     // where it is used simply to get a list of G4AttDefs.
     //    G4Exception

--- a/source/visualization/modeling/src/G4TrajectoryDrawByAttribute.cc
+++ b/source/visualization/modeling/src/G4TrajectoryDrawByAttribute.cc
@@ -146,7 +146,7 @@ G4TrajectoryDrawByAttribute::Draw(const G4VTrajectory& object,
   if (filter->GetValidElement(attVal, key)) {
 
     // Extract context corresponding to valid key.
-    // Single value match should have overriden interval match.
+    // Single value match should have overridden interval match.
     ContextMap::const_iterator iter = fContextMap.begin();
 
     G4bool gotContext(false);


### PR DESCRIPTION
Found via `codespell -q 3 -S ./source/externals -L acn,ans,asai,build-in,highe,inactivate,lastr,nam,nin,nnumber,parms,statics,te,ther,thes,thess,twon`