### PR TITLE
Avoid precision loss using std::erf(x) in processes/electromagnetic/dna/utils/src/G4ErrorFunction.cc

### DIFF
--- a/source/processes/electromagnetic/dna/utils/include/G4ErrorFunction.hh
+++ b/source/processes/electromagnetic/dna/utils/include/G4ErrorFunction.hh
@@ -53,7 +53,6 @@
 #define G4ERRORFUNCTION_HH_
 
 #include "globals.hh"
-#include <vector>
 
 class G4ErrorFunction {
 public:

--- a/source/processes/electromagnetic/dna/utils/src/G4ErrorFunction.cc
+++ b/source/processes/electromagnetic/dna/utils/src/G4ErrorFunction.cc
@@ -53,7 +53,7 @@
 #include "globals.hh"
 #include "G4SystemOfUnits.hh"
 #include "Randomize.hh"
-#include <vector>
+#include <cmath>
 
 
 G4ErrorFunction::G4ErrorFunction() {;}
@@ -584,7 +584,7 @@ G4double G4ErrorFunction::erfcx(G4double x)
 
 
 G4double G4ErrorFunction::erfc(G4double x) {
-    return 1.0 - std::erf(x);
+    return std::erfc(x);
 }
 
 


### PR DESCRIPTION
Using the C++ 11 built in function std::erfc instead of 1.0 - std::erf, to avoid precision loss for large values.