### PR TITLE
Fix on nasty bug due to fp approximation in PenelopeCompton model

### DIFF
--- a/source/processes/electromagnetic/lowenergy/include/G4PenelopeComptonModel.hh
+++ b/source/processes/electromagnetic/lowenergy/include/G4PenelopeComptonModel.hh
@@ -127,6 +127,7 @@ private:
 
   G4int fVerboseLevel;
   G4bool fIsInitialised;
+  G4double taumax; 
 };
 
 #endif

--- a/source/processes/electromagnetic/lowenergy/src/G4PenelopeComptonModel.cc
+++ b/source/processes/electromagnetic/lowenergy/src/G4PenelopeComptonModel.cc
@@ -338,7 +338,7 @@ void G4PenelopeComptonModel::SampleSecondaries(std::vector<G4DynamicParticle*>* 
 	    tau = std::sqrt(1.0+G4UniformRand()*(taumin*taumin-1.0));
 	  //rejection function
 	  TST = (1.0+tau*(ek1+tau*(ek2+tau*eks)))/(eks*tau*(1.0+tau*tau));
-	}while (G4UniformRand()> TST);
+	}while ((G4UniformRand()> TST) && (tau==1.0));
 	epsilon=tau;
 	cosTheta = 1.0 - (1.0-tau)/(ek*tau);
 
@@ -390,10 +390,12 @@ void G4PenelopeComptonModel::SampleSecondaries(std::vector<G4DynamicParticle*>* 
       G4double cdt1 = 0.;
       do
 	{
+    do{
 	  if ((G4UniformRand()*a2) < a1)
 	    tau = std::pow(taumin,G4UniformRand());
 	  else
 	    tau = std::sqrt(1.0+G4UniformRand()*(taumin*taumin-1.0));
+    } while (tau==1.0);
 	  cdt1 = (1.0-tau)/(ek*tau);
 	  //Incoherent scattering function
 	  S = 0.;

--- a/source/processes/electromagnetic/lowenergy/src/G4PenelopeComptonModel.cc
+++ b/source/processes/electromagnetic/lowenergy/src/G4PenelopeComptonModel.cc
@@ -335,10 +335,10 @@ void G4PenelopeComptonModel::SampleSecondaries(std::vector<G4DynamicParticle*>* 
 	  if ((a2*G4UniformRand()) < a1)
 	    tau = std::pow(taumin,G4UniformRand());
 	  else
-	    tau = std::sqrt(1.0+G4UniformRand()*(taumin*taumin-1.0));
+	    tau = std::min(std::sqrt(1.0+G4UniformRand()*(taumin*taumin-1.0)) ,1.0-1e-12);
 	  //rejection function
 	  TST = (1.0+tau*(ek1+tau*(ek2+tau*eks)))/(eks*tau*(1.0+tau*tau));
-	}while ((G4UniformRand()> TST) && (tau==1.0));
+	}while (G4UniformRand()> TST);
 	epsilon=tau;
 	cosTheta = 1.0 - (1.0-tau)/(ek*tau);
 
@@ -390,12 +390,10 @@ void G4PenelopeComptonModel::SampleSecondaries(std::vector<G4DynamicParticle*>* 
       G4double cdt1 = 0.;
       do
 	{
-    do{
 	  if ((G4UniformRand()*a2) < a1)
 	    tau = std::pow(taumin,G4UniformRand());
 	  else
-	    tau = std::sqrt(1.0+G4UniformRand()*(taumin*taumin-1.0));
-    } while (tau==1.0);
+	    tau = std::min(std::sqrt(1.0+G4UniformRand()*(taumin*taumin-1.0)) ,1.0-1e-12);
 	  cdt1 = (1.0-tau)/(ek*tau);
 	  //Incoherent scattering function
 	  S = 0.;


### PR DESCRIPTION
# Bug description 
When running a simulation with a material that has a combination of the elements (H,C,O,N), then ionEnergy may happen to be 0. This wouldn't be a problem, but if also happen that tau is 1, then the algorithm ends in an infinite loop later in the code around line 456 of the PenelopeCompton file. Tau ==1.0 happens due to FP approximation when applying the sqrt() on math-expr near to 1.0 because G4UniformRand() has extracted near to 0.0.

# Expected Behaviour
PenelopeCompton working flawlessly as model.  tau==1.0 was expected to never happen (it seems it should be in (taumin,1) ), but it happens and forces the code to reach an endless cycle when using materials that are a (common) combination of  (H,C,O,N) with ionEnergy==0. 

# Notes
- This under the assumption that ionEnergy==0.0 in the PenelopeCompton-table is a correct value
- Perhaps it is possible to substitute the loop condition with a matematical little epsilon value that prevents tau ==1.0 and shift it to a little smaller value.


