### PR TITLE
Improve perf of Legendre polynomial calculations

### DIFF
--- a/source/processes/hadronic/models/de_excitation/photon_evaporation/src/G4PolarizationTransition.cc
+++ b/source/processes/hadronic/models/de_excitation/photon_evaporation/src/G4PolarizationTransition.cc
@@ -153,9 +153,6 @@ G4double G4PolarizationTransition::GenerateGammaPhi(G4double& cosTheta,
     }
   }
   if(phiIsIsotropic) { return G4UniformRand()*CLHEP::twopi; }
-
-  map<G4int, map<G4int, G4double> >* cachePtr = nullptr;
-
   // Otherwise, P(phi) can be written as a sum of cos(kappa phi + phi_kappa).
   // Calculate the amplitude and phase for each term
   std::vector<G4double> amp(length, 0.0);
@@ -169,7 +166,7 @@ G4double G4PolarizationTransition::GenerateGammaPhi(G4double& cosTheta,
         G4double tmpAmp = GammaTransFCoefficient(k);
         if(tmpAmp == 0) { continue; }
         tmpAmp *= std::sqrt((G4double)(2*k+1)) 
-	  * fgLegendrePolys.EvalAssocLegendrePoly(k, kappa, cosTheta, cachePtr);
+	  * fgLegendrePolys.EvalAssocLegendrePoly(k, kappa, cosTheta);
         if(kappa > 0) tmpAmp *= 2.*G4Exp(0.5*(LnFactorial(k-kappa) - LnFactorial(k+kappa)));
         cAmpSum += ((pol)[k])[kappa]*tmpAmp;
       } else {
@@ -280,10 +277,6 @@ void G4PolarizationTransition::SampleGammaTransition(
   //POLAR newPol(newlength);
   POLAR newPol;
 
-  //map<G4int, map<G4int, G4double> > cache;
-  map<G4int, map<G4int, G4double> >* cachePtr = nullptr;
-  //if(newlength > 10 || pol.size() > 10) cachePtr = &cache;
-
   for(G4int k2=0; k2<(G4int)newlength; ++k2) {
     std::vector<G4complex> npolar;
     npolar.resize(k2+1, 0);
@@ -317,7 +310,7 @@ void G4PolarizationTransition::SampleGammaTransition(
             //AR-13Jun2017 Useful for debugging very long computations
             //G4cout << "G4PolarizationTransition::UpdatePolarizationToFinalState : k1=" << k1 
             //       << " ; k2=" << k2 << " ; kappa1=" << kappa1 << " ; kappa2=" << kappa2 << G4endl;
-            tmpAmp *= fgLegendrePolys.EvalAssocLegendrePoly(k, kappa, cosTheta, cachePtr);
+            tmpAmp *= fgLegendrePolys.EvalAssocLegendrePoly(k, kappa, cosTheta);
             if(kappa != 0) {
               tmpAmp *= G4Exp(0.5*(LnFactorial(((G4int)k)-kappa) 
 				   - LnFactorial(((G4int)k)+kappa)));

--- a/source/processes/hadronic/util/include/G4LegendrePolynomial.hh
+++ b/source/processes/hadronic/util/include/G4LegendrePolynomial.hh
@@ -56,8 +56,16 @@ class G4LegendrePolynomial
 
     // Evaluation functions
     G4double EvalLegendrePoly(G4int order, G4double x);
+
+    G4double EvalAssocLegendrePoly(G4int l, G4int m, G4double x);
+
+    // cache is not used; use EvalAssocLegendrePoly(l, m, x) instead.
     G4double EvalAssocLegendrePoly(G4int l, G4int m, G4double x,
-                                   std::map<G4int, std::map<G4int, G4double> >* cache = NULL);
+      std::map<G4int, std::map<G4int, G4double> >* cache)
+    {
+      (void) cache; // suppress compiler warning for unused cache
+      return EvalAssocLegendrePoly(l, m, x); 
+    }
 
   protected: // Cache coefficients for speed
     void BuildUpToOrder(size_t order);

--- a/source/processes/hadronic/util/src/G4LegendrePolynomial.cc
+++ b/source/processes/hadronic/util/src/G4LegendrePolynomial.cc
@@ -46,78 +46,96 @@ G4double G4LegendrePolynomial::EvalLegendrePoly(G4int order, G4double x)
   return (EvalAssocLegendrePoly(order,0,x));
 }
 
-G4double G4LegendrePolynomial::EvalAssocLegendrePoly(G4int l, G4int m, G4double x, 
-                                                     map<G4int, map<G4int, G4double> >* cache)
+G4double G4LegendrePolynomial::EvalAssocLegendrePoly(G4int l, G4int m, G4double x)
 {
-  // Calculate P_l^m(x).
-  // If cache ptr is non-null, use cache[l][m] if it exists, otherwise compute
-  // P_l^m(x) and cache it in that position. The cache speeds up calculations
-  // where many P_l^m computations are need at the same value of x.
+  // Invalid calls --> 0. (Keeping for backward compatibility; should we throw instead?)
+  if (l<0 || m<-l || m>l) return 0.0;
 
-  if(l<0 || m<-l || m>l) return 0;
-  G4Pow* g4pow =  G4Pow::GetInstance();
+  // New check: g4pow doesn't handle integer arguments over 512.
+  // For us that means:
+  if ((l+m) > 512 || (l-m) > 512 || (2*m) > 512) return 0.0; 
 
-  // Use non-log factorial for low l, m: it is more efficient until 
-  // l and m get above 10 or so.
-  // FIXME: G4Pow doesn't check whether the argument gets too large, 
-  // which is unsafe! Max is 512; VI: It is assume that Geant4 does not
-  // need higher order
-  if(m<0) {
-    G4double value = (m%2 ? -1. : 1.) * EvalAssocLegendrePoly(l, -m, x);
-    if(l < 10) return value * g4pow->factorial(l+m)/g4pow->factorial(l-m);
-    else { return value * G4Exp(g4pow->logfactorial(l+m) - g4pow->logfactorial(l-m));
-    }
-  }
+  G4Pow* g4pow = G4Pow::GetInstance();
+  G4double x2 = x*x;
 
   // hard-code the first few orders for speed
-  if(l==0)   return 1;
-  if(l==1) {
-    if(m==0){return x;}
-    /*m==1*/ return -sqrt(1.-x*x);
-  }
-  if(l<5) {
-    G4double x2 = x*x;
-    if(l==2) {
-      if(m==0){return 0.5*(3.*x2 - 1.);}
-      if(m==1){return -3.*x*sqrt(1.-x2);}
-      /*m==2*/ return 3.*(1.-x2);
-    }
-    if(l==3) {
-      if(m==0){return 0.5*(5.*x*x2 - 3.*x);}
-      if(m==1){return -1.5*(5.*x2-1.)*sqrt(1.-x2);}
-      if(m==2){return 15.*x*(1.-x2);}
-      /*m==3*/ return -15.*(1.-x2)*sqrt(1.-x2);
-    }
-    if(l==4) {
-      if(m==0){return 0.125*(35.*x2*x2 - 30.*x2 + 3.);}
-      if(m==1){return -2.5*(7.*x*x2-3.*x)*sqrt(1.-x2);}
-      if(m==2){return 7.5*(7.*x2-1.)*(1.-x2);}
-      if(m==3){return -105.*x*(1.-x2)*sqrt(1.-x2);}
-      /*m==4*/ return 105.*(1. - 2.*x2 + x2*x2);
-    }
-  }
+  switch (l) {
+    case 0 : 
+      return 1;
+    case 1 : 
+      switch (m) {
+        case -1 : return 0.5 * sqrt(1.-x2); 
+        case 0 : return x;
+        case 1 : return -sqrt(1.-x2);
+      }; 
+      break;
+    case 2 :
+      switch (m) {
+        case -2 : return 0.125 * (1.0 - x2);
+        case -1 : return 0.5 * x * sqrt(1.0 - x2);
+        case 0 : return 0.5*(3.*x2 - 1.);
+        case 1 : return -3.*x*sqrt(1.-x2); 
+        case 2 : return 3.*(1.-x2);
+      };
+      break;
+    case 3 : 
+      switch (m) {
+        case -3 : return (1.0/48.0) * (1.0 - x2) * sqrt(1.0 - x2);
+        case -2 : return 0.125 * x * (1.0 - x2);
+        case -1 : return 0.125 * (5.0 * x2 - 1.0) * sqrt(1.0 - x2);
+        case 0 : return 0.5*(5.*x*x2 - 3.*x);
+        case 1 : return -1.5*(5.*x2-1.)*sqrt(1.-x2);
+        case 2 : return 15.*x*(1.-x2);
+        case 3 : return -15.*(1.-x2)*sqrt(1.-x2);
+      };
+      break;
+    case 4 :
+      switch (m) {
+        case -4 : return (105.0/40320.0)*(1. - 2.*x2 + x2*x2);
+        case -3 : return (105.0/5040.0)*x*(1.-x2)*sqrt(1.-x2);
+        case -2 : return (15.0/720.0)*(7.*x2-1.)*(1.-x2);
+        case -1 : return 0.125*(7.*x*x2-3.*x)*sqrt(1.-x2);
+        case 0 : return 0.125*(35.*x2*x2 - 30.*x2 + 3.);
+        case 1 : return -2.5*(7.*x*x2-3.*x)*sqrt(1.-x2);
+        case 2 : return 7.5*(7.*x2-1.)*(1.-x2);
+        case 3 : return -105.*x*(1.-x2)*sqrt(1.-x2);
+        case 4 : return 105.*(1. - 2.*x2 + x2*x2);
+      };
+      break;
+  };
 
-  // Easy special cases
-  // FIXME: G4Pow doesn't check whether the argument gets too large, which is unsafe! Max is 512. 
-  if(m==l) return (l%2 ? -1. : 1.) * 
-	     G4Exp(g4pow->logfactorial(2*l) - g4pow->logfactorial(l)) * 
-	     G4Exp(G4Log((1.-x*x)*0.25)*0.5*G4double(l));
-  if(m==l-1) return x*(2.*G4double(m)+1.)*EvalAssocLegendrePoly(m,m,x);
+  // if m<0, compute P[l,-m,x] and correct
+  if (m < 0)
+  {
+    G4double complementary_value = EvalAssocLegendrePoly(l, -m, x);
+    return complementary_value * (m%2==0 ? 1.0 : -1.0) * g4pow->factorial(l+m)/g4pow->factorial(l-m);
+  } 
 
-  // See if we have this value cached.
-  if(cache != NULL && cache->count(l) > 0 && (*cache)[l].count(m) > 0) {
-    return (*cache)[l][m];
+  // Iteratively walk up from P[m,m,x] to P[l,m,x]
+
+  // prime the pump: P[l<m,m,x] = 0
+  G4double previous = 0.0;
+
+  // prime the pump: P[m,m,x]
+  G4double current; 
+  if (m == 0) current = 1.0;
+  else if (m == 1) current = -sqrt((1.0 - (x2)));
+  else {
+    current = (m%2==0 ? 1.0 : -1.0) * 
+	     G4Exp(g4pow->logfactorial(2*m) - g4pow->logfactorial(m)) * 
+	     G4Exp(G4Log((1.0-(x2))*0.25)*0.5*G4double(m));
   }
-
-  // Otherwise calculate recursively
-  G4double value = (x*G4double(2*l-1)*EvalAssocLegendrePoly(l-1,m,x) - 
-	           (G4double(l+m-1))*EvalAssocLegendrePoly(l-2,m,x))/G4double(l-m);
-
-  // If we are working with a cache, cache this value.
-  if(cache != NULL) {
-    (*cache)[l][m] = value;
+  
+  // Work up to P[l,m,x] 
+  for(G4int i=m+1; i<=l; i++)
+  {
+    G4double next = (-(G4double(i+m-1))*previous + x*G4double(2*i-1)*current )/G4double(i-m);
+    //G4double next = (-(G4double(i+m-1))*previous - x*G4double(2*i-1)*current )/G4double(i-m);  // INCORRECT
+    previous = current;
+    current = next;
   }
-  return value;
+  
+  return current;
 }
 
 void G4LegendrePolynomial::BuildUpToOrder(size_t orderMax)


### PR DESCRIPTION
The current code for calculating associated Legengre polynomials in G4LegendrePolynomial has two issues:

1. It is a recursive solution to a recurrence whose time grows exponentially without a cache/memoization.

2. The code can take a user-provided cache, but the user must be careful to supply a fresh cache for for each value of x or wrong results will be generated (silently).

This commit rewrites the G4LegendrePolynomial::EvalAssocLegendrePoly routine to address both of these issues:

1. It iteratively walks up from P[m,m,x] to P[l,m,x] in O(l-m) time.

2. It eliminates use of the cache entirely. A new signature without the cache has been introduced, and any call made with a cache falls through to this new one. The cache-bearing call has been retained in case any external callers rely on it.

3. There do not appear to be any references to this method in the Geant4 codebase itself that pass a non-null cache. The few references that do exist are in G4PolarizationTransition; these have been rewritten to use the cache-free call.

4. The list of special cases for small l and m values has been slightly expended (to negative m) and restructured as a case statement, primarily to improve readability. These have been retained since they appear to offer a modest performance benefit for these small cases.

This new method appears to perform better (often substantially better) than the old one over all tested parameters, even when a proper cache was used. It uses the same recurrence as the old method, and results seem identical.