### PR TITLE
Fix MacOS compiler errors

### DIFF
--- a/source/analysis/management/include/G4THnToolsManager.icc
+++ b/source/analysis/management/include/G4THnToolsManager.icc
@@ -297,7 +297,7 @@ template <unsigned int DIM, typename HT>
 G4String G4THnToolsManager<DIM, HT>::GetTitle(G4int id) const
 {
   auto ht = GetTInFunction(id, "GetTitle");
-  if (ht == nullptr) return 0;
+  if (ht == nullptr) return "";
 
   return ht->title();
 }
@@ -308,7 +308,7 @@ template <unsigned int DIM, typename HT>
 G4String G4THnToolsManager<DIM, HT>::GetAxisTitle(unsigned int idim, G4int id) const
 {
   auto ht = GetTInFunction(id, "GetAxisTitle");
-  if (ht == nullptr) return 0;
+  if (ht == nullptr) return "";
 
   G4String title;
   G4bool result = ht->annotation(fkKeyAxisTitle[idim], title);

--- a/source/digits_hits/hits/include/G4THitsMap.hh
+++ b/source/digits_hits/hits/include/G4THitsMap.hh
@@ -33,6 +33,7 @@
 
 #include <map>
 #include <unordered_map>
+#include <type_traits>
 
 // class description:
 //


### PR DESCRIPTION
Fix the following two compilation errors in MacOS

1. error: no member named 'is_fundamental' in namespace 'std'

error log:
```
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:65:41: error: no member named 'is_fundamental' in namespace 'std'
  template <typename U = T, enable_if_t<is_fundamental_t(U), G4int> = 0>
                                        ^~~~~~~~~~~~~~~~~~~
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:59:36: note: expanded from macro 'is_fundamental_t'
#define is_fundamental_t(_Tp) std::is_fundamental<_Tp>::value
                              ~~~~~^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:65:58: error: 'U' does not refer to a value
  template <typename U = T, enable_if_t<is_fundamental_t(U), G4int> = 0>
                                                         ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:65:22: note: declared here
  template <typename U = T, enable_if_t<is_fundamental_t(U), G4int> = 0>
                     ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:65:69: error: expected member name or ';' after declaration specifiers
  template <typename U = T, enable_if_t<is_fundamental_t(U), G4int> = 0>
                                                                    ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:101:3: error: unknown type name 'this_type'
  this_type& operator+=(const G4VTHitsMap<U, MapU_t>& right) const
  ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:106:23: error: expected expression
    return (this_type&)(*this);
                      ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:106:13: error: use of undeclared identifier 'this_type'
    return (this_type&)(*this);
            ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:202:14: error: use of undeclared identifier 'allocate'
    T* hit = allocate();
             ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:235:84: error: use of undeclared identifier 'allocate'
    if (theHitsMap->find(key) == theHitsMap->end()) theHitsMap->insert(pair_t(key, allocate()));
                                                                                   ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:259:14: error: use of undeclared identifier 'allocate'
    T* hit = allocate();
             ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:308:52: error: use of undeclared identifier 'allocate'
      theHitsMap->insert(std::make_pair(key, hit = allocate()));
                                                   ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:322:14: error: use of undeclared identifier 'allocate'
    T* hit = allocate();
             ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:350:44: error: use of undeclared identifier 'allocate'
      theHitsMap->insert(pair_t(key, hit = allocate()));
                                           ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:378:52: error: use of undeclared identifier 'allocate'
      theHitsMap->insert(std::make_pair(key, hit = allocate()));
                                                   ^
/Users/edwin/software/geant4/latest/include/Geant4/G4THitsMap.hh:392:14: error: use of undeclared identifier 'allocate'
    T* hit = allocate();
```

2. conversion function from 'int' to 'G4String' invokes a deleted function

Error log:
```
/Users/edwin/software/geant4/latest/include/Geant4/G4THnToolsManager.icc:311:29: error: conversion function from 'int' to 'G4String' invokes a deleted function
  if (ht == nullptr) return 0;
                            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/string:951:3: note: 'basic_string' has been explicitly marked deleted here
  basic_string(nullptr_t) = delete;
```