### PR TITLE
G4ParticleMessenger: fix incorrect GetCurrentValue implementation for G4ParticleMessenger

### DIFF
--- a/source/particles/management/include/G4ParticleMessenger.hh
+++ b/source/particles/management/include/G4ParticleMessenger.hh
@@ -94,7 +94,6 @@ class G4ParticleMessenger : public G4UImessenger
     G4UIcmdWithAnInteger* verboseCmd = nullptr;
 
     G4ParticleTable* theParticleTable = nullptr;
-    G4ParticleDefinition* currentParticle = nullptr;
 
     G4ParticlePropertyMessenger* fParticlePropertyMessenger = nullptr;
 };

--- a/source/particles/management/src/G4ParticleMessenger.cc
+++ b/source/particles/management/src/G4ParticleMessenger.cc
@@ -201,6 +201,7 @@ G4String G4ParticleMessenger::GetCurrentValue(G4UIcommand* command)
     }
     selectCmd->SetCandidates((const char*)(candidates));
 
+    const G4ParticleDefinition* currentParticle = theParticleTable->GetSelectedParticle();
     static const G4String noName("none");
     // current value
     if (currentParticle == nullptr) {


### PR DESCRIPTION
This fixes a following bug:

```
Idle> /particle/select lambda
Idle> /particle/property/dump

--- G4ParticleDefinition ---
 Particle Name : lambda
 PDG particle code : 3122 [PDG anti-particle code: -3122]
 Mass [GeV/c2] : 1.11568     Width : 2.501e-15
 Lifetime [nsec] : 0.2631
 Charge [e]: 0
 Spin : 1/2
 Parity : 1
 Charge conjugation : 0
 Isospin : (I,Iz): (0/2 , 0/2 ) 
 GParity : 0
 MagneticMoment [MeV/T] : -1.93245e-14
 Quark contents     (d,u,s,c,b,t) : 1, 1, 1, 0, 0, 0
 AntiQuark contents               : 0, 0, 0, 0, 0, 0
 Lepton number : 0 Baryon number : 1
 Particle type : baryon [lambda]
G4DecayTable:  lambda
0:  BR:  0.639  [Phase Space]   :   proton pi-
1:  BR:  0.358  [Phase Space]   :   neutron pi0

Idle> /particle/property/decay/dump
Particle is not selected yet !! Command ignored.
```

The issue is that `currentParticle` is always `nullptr`, so when `G4DecayTableMessenger` tries to use `GetCurrentStringValue` with `reGet=true` default, it can never get a non-null particle pointer.