### PR TITLE
missing value in DNA PTB Ionization Structure; missing GetMaterial() in DNA PTB Excitation and Elastic models;

### DIFF
--- a/source/processes/electromagnetic/dna/models/src/G4DNAPTBElasticModel.cc
+++ b/source/processes/electromagnetic/dna/models/src/G4DNAPTBElasticModel.cc
@@ -368,7 +368,7 @@ void G4DNAPTBElasticModel::SampleSecondaries(std::vector<G4DynamicParticle*>* /*
   }
 
   G4double electronEnergy0 = aDynamicElectron->GetKineticEnergy();
-  const std::size_t& materialID = couple->GetIndex();
+  const std::size_t& materialID = couple->GetMaterial()->GetIndex();
   auto p = aDynamicElectron->GetParticleDefinition();
 
   // set killBelowEnergy value for material

--- a/source/processes/electromagnetic/dna/models/src/G4DNAPTBExcitationModel.cc
+++ b/source/processes/electromagnetic/dna/models/src/G4DNAPTBExcitationModel.cc
@@ -255,7 +255,7 @@ void G4DNAPTBExcitationModel::SampleSecondaries(std::vector<G4DynamicParticle*>*
                                                 const G4DynamicParticle* aDynamicParticle,
                                                 G4double /*tmin*/, G4double /*tmax*/)
 {
-  const std::size_t& materialID = (std::size_t)couple->GetIndex();
+  const std::size_t& materialID = (std::size_t)couple->GetMaterial()->GetIndex();
 
   // Get the incident particle kinetic energy
   G4double k = aDynamicParticle->GetKineticEnergy();

--- a/source/processes/electromagnetic/dna/utils/src/G4DNAPTBIonisationStructure.cc
+++ b/source/processes/electromagnetic/dna/utils/src/G4DNAPTBIonisationStructure.cc
@@ -52,6 +52,7 @@ G4DNAPTBIonisationStructure::G4DNAPTBIonisationStructure()
     energyConstant[index].push_back(17.07 * eV);
     energyConstant[index].push_back(21.00 * eV);
     energyConstant[index].push_back(41.72 * eV);
+    energyConstant[index].push_back(409.9*eV);
   }
 
   // MPietrzak


### PR DESCRIPTION
I have found out that there is one value missing for nitrogen in G4DNAPTBIonisationStructure.cc. I'm the original author of this piece of code (http://dx.doi.org/10.1016/j.ejmp.2022.09.003). The corresponding cross-sections for that energy shell are present in "G4EMLOW8.*/dna" dataset since version 8.2, so no further corrections are needed.

Additionally, I have found a bug repeated twice in G4DNAPTBElasticModel and in G4DNAPTBExcitationModel in their respective SampleSecondaries() methods. Namely, a missing GetMaterial() method resulted in the wrong value of the materialID variable. I found the solution in the G4DNAPTBIonizationModel, where materialID is retrieved correctly.