### PR TITLE
fix a typo (that can cause build failure)

### DIFF
--- a/source/externals/g4tools/include/tools/wroot/columns.icc
+++ b/source/externals/g4tools/include/tools/wroot/columns.icc
@@ -399,7 +399,7 @@
   protected:
     std_vector_column_ref(const std_vector_column_ref& a_from)
     :icol(a_from)
-    ,m_branch(a_from.m_barnch)
+    ,m_branch(a_from.m_branch)
     ,m_ref(a_from.m_ref)
     ,m_leaf(0)
     ,m_leaf_count(0)


### PR DESCRIPTION
I faced the issue when compiling Geant4, there are similar reports online like: https://bugs.gentoo.org/938604