### PR TITLE
fix(processes/scoring): get phantom param from step

### DIFF
--- a/source/processes/scoring/include/private/G4EnergySplitter.hh
+++ b/source/processes/scoring/include/private/G4EnergySplitter.hh
@@ -72,7 +72,6 @@ class G4EnergySplitter
   private:
     void GetStepLength(G4int stepNo, G4double& stepLength);
 
-    void GetPhantomParam(G4bool mustExist);
     G4bool IsPhantomVolume(G4VPhysicalVolume* pv);
 
     G4EnergyLossForExtrapolator* theElossExt;

--- a/source/processes/scoring/include/private/G4EnergySplitter.icc
+++ b/source/processes/scoring/include/private/G4EnergySplitter.icc
@@ -66,7 +66,10 @@ inline void G4EnergySplitter::SetNIterations(G4int niter)
 //-----------------------------------------------------------------------
 inline G4Material* G4EnergySplitter::GetVoxelMaterial(G4int stepNo)
 {
-  if (thePhantomParam == nullptr) GetPhantomParam(true);
+  if (thePhantomParam == nullptr) {
+    G4Exception("G4EnergySplitter::GetVoxelMaterial()", "PhantomParamError",
+                FatalException, "Phantom parameterisation not set -- SplitEnergyInVolumes() must be called first");
+  }
   G4int voxelID;
   GetVoxelID(stepNo, voxelID);
   return thePhantomParam->GetMaterial(voxelID);

--- a/source/processes/scoring/src/G4EnergySplitter.cc
+++ b/source/processes/scoring/src/G4EnergySplitter.cc
@@ -78,7 +78,14 @@ G4int G4EnergySplitter::SplitEnergyInVolumes(const G4Step* aStep)
     return (G4int)theEnergies.size();
   }
 
-  if (thePhantomParam == nullptr) GetPhantomParam(true);
+  //----- Get the phantom parameterisation from the G4Step
+  auto preStepPhysVol = aStep->GetPreStepPoint()->GetPhysicalVolume();
+  if (!IsPhantomVolume(preStepPhysVol)) {
+    G4Exception("G4EnergySplitter::SplitEnergyInVolumes", "PhantomParamError", FatalException,
+                "SplitEnergyInVolumes() called for a step not in a phantom volume");
+  }
+  auto phantomVol = static_cast<G4PVParameterised*>(preStepPhysVol);
+  thePhantomParam = static_cast<G4PhantomParameterisation*>(phantomVol->GetParameterisation());
 
   //----- Distribute energy deposited in voxels
   std::vector<std::pair<G4int, G4double>> rnsl =
@@ -272,23 +279,6 @@ G4int G4EnergySplitter::SplitEnergyInVolumes(const G4Step* aStep)
   }
 
   return (G4int)theEnergies.size();
-}
-
-//-----------------------------------------------------------------------
-void G4EnergySplitter::GetPhantomParam(G4bool mustExist)
-{
-  G4PhysicalVolumeStore* pvs = G4PhysicalVolumeStore::GetInstance();
-  for (const auto pv : *pvs) {
-    if (IsPhantomVolume(pv)) {
-      const auto pvparam = static_cast<const G4PVParameterised*>(pv);
-      G4VPVParameterisation* param = pvparam->GetParameterisation();
-      thePhantomParam = static_cast<G4PhantomParameterisation*>(param);
-    }
-  }
-
-  if ((thePhantomParam == nullptr) && mustExist)
-    G4Exception("G4EnergySplitter::GetPhantomParam", "PhantomParamError", FatalException,
-                "No G4PhantomParameterisation found !");
 }
 
 //-----------------------------------------------------------------------


### PR DESCRIPTION
This commit resolves [Bugzilla/Geant4 – Problem 2636](https://bugzilla-geant4.kek.jp/show_bug.cgi?id=2636).

The changes to G4EnergySplitter here are focused on ensuring that each call to SplitEnergyInVolumes() utilizes the correct phantom parameterization.  This involves the removal of the GetPhantomParam private method in favor of fetching the parameterization from the G4Step on each invocation of SplitEnergyInVolumes().  New exceptions are thrown if the G4Step does not refer to an appropriate phantom, or if the instance variable `thePhantomParam` is required but has not yet been initialized in SplitEnergyInVolumes().

> [!NOTE]
> No tests have been added to accompany this change since the ContinuousTest build target and all other build targets seem to have no tests to build on 🤷‍♂️.