### PR TITLE
Add cmake option to set soversion for shared libs.

### DIFF
--- a/cmake/Modules/G4BuildSettings.cmake
+++ b/cmake/Modules/G4BuildSettings.cmake
@@ -470,6 +470,10 @@ endif()
 #
 #   - Build static libraries (`.a` on Unices, `.lib` on Windows)
 #
+# - ``GEANT4_SHARED_LIB_SOVERSION`` (Default: ``OFF``)
+#
+#   - Add version and soversion to shared libraries
+#
 # Both options are adavanced and may be selected together to build
 # both types. If neither is selected, an error is emitted.
 #
@@ -482,6 +486,9 @@ mark_as_advanced(BUILD_SHARED_LIBS BUILD_STATIC_LIBS)
 if(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
   message(FATAL_ERROR "Neither static nor shared libraries will be built")
 endif()
+
+option(GEANT4_SHARED_LIB_SOVERSION "Add version and soversion to shared libs" OFF)
+mark_as_advanced(GEANT4_SHARED_LIB_SOVERSION)
 
 # Always build global libraries - always FATAL_ERROR if old
 # granular library switch is set, e.g. from command line

--- a/cmake/Modules/G4DeveloperAPI.cmake
+++ b/cmake/Modules/G4DeveloperAPI.cmake
@@ -1309,6 +1309,15 @@ function(__geant4_add_library _name _type)
     target_compile_definitions(${_target_name} PUBLIC G4LIB_BUILD_DLL)
     set_target_properties(${_target_name} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
+    # Unix
+    # Add version and soversion to shared libraries
+    if (UNIX AND GEANT4_SHARED_LIB_SOVERSION)
+      set_target_properties(${_target_name} PROPERTIES
+        VERSION ${${PROJECT_NAME}_VERSION}
+        SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR}
+      )
+    endif()
+
     # MacOS
     # Use '@rpath' in install names of libraries on macOS to provide relocatibility
     # Add '@loader_path' to INSTALL_RPATH on macOS so that Geant4


### PR DESCRIPTION
Add cmake option GEANT4_SHARED_LIB_SOVERSION (default: OFF) to add VERSION and SOVERSION properties to shared libraries.

If enabled, for each G4 module built as a shared library, add VERSION and SOVERSION properties to follow semantic versioning. Set the shared lib VERSION property to the full version of the project, and SOVERSION to the project major version. An update to the latter would represent backward incompatible API changes corresponding to a major version release.

This option only affects shared library naming on UNIX.

This option has no effect on static libraries.