### PR TITLE
Fix: Patch for the Gammaknife example in Geant4 v11.3.2

### DIFF
--- a/examples/advanced/gammaknife/defaultMacro.mac
+++ b/examples/advanced/gammaknife/defaultMacro.mac
@@ -20,6 +20,7 @@
 /score/mesh/boxSize 22.5 22.5 22.5 mm
 /score/mesh/rotate/rotateX 360 deg          # Note: Hack to enable rotation (as of 10.3)
 /score/mesh/nBin 45 45 45
+/score/mesh/translate/xyz 0. 0. 0. cm # position boxmesh at the location of "patient"
 /score/quantity/energyDeposit eDep
 /score/close
 /score/list
@@ -33,6 +34,7 @@
 
 # Open a viewer
 /vis/open
+/vis/drawVolume
 # This opens the default viewer - see examples/basic/B1/vis.mac for a
 # more comprehensive overview of options. Also the documentation.
 


### PR DESCRIPTION
The problem:
- The visualization is not drawing the geometry on the simulation

- boxMesh is not being placed correctly, so the eDep file shows all zeroes on deposited energy.

The following diff file fix these issues:

- geometry is drawn with /vis/drawVolume

- boxmesh is positioned at where the patient(a sphere geometry with water) is present(with /mesh/score/translate/xyz 0. 0. 0. cm)