### PR TITLE
Prevent memleak when clearing secondaries

### DIFF
--- a/source/processes/hadronic/util/include/G4HadFinalState.hh
+++ b/source/processes/hadronic/util/include/G4HadFinalState.hh
@@ -84,7 +84,7 @@ public:
   G4double GetLocalEnergyDeposit() const         { return theEDep;}
   //  void SecondariesAreStale();    // Deprecated; not needed for values
   inline
-  void ClearSecondaries()                        { theSecs.clear(); }
+  void ClearSecondaries()                        { for (auto& sec : theSecs) delete sec.GetParticle(); theSecs.clear(); }
 
   // Concatenate lists efficiently
   void AddSecondaries(const std::vector<G4HadSecondary>& addSecs);


### PR DESCRIPTION
The following files:

```
processes/hadronic/models/coherent_elastic/src/G4ChargeExchange.cc
processes/hadronic/models/coherent_elastic/src/G4HadronElastic.cc
processes/hadronic/models/coherent_elastic/src/G4LMsdGenerator.cc
processes/hadronic/models/coherent_elastic/src/G4NeutrinoElectronNcModel.cc
processes/hadronic/models/coherent_elastic/src/G4NeutronElectronElModel.cc
processes/hadronic/models/lepto_nuclear/src/G4NeutrinoNucleusModel.cc 
```

have calls of the type:

`G4DynamicParticle * aSec = new G4DynamicParticle(theDef, lv.vect().unit(), erec); theParticleChange.AddSecondary(aSec, secID);`

But no one was taking care of deleting this new memory when clearing that vector.

The memleak was observed in
https://geant4-forum.web.cern.ch/t/memory-usage-in-g4hadronicinteraction-applyyourself/11437/4 https://geant4-forum.web.cern.ch/t/increasing-memory-usage-with-g4hadronelastic-applyyourself/14480/10

and a workaround was proposed on the user-side call to fix this, but the proper way should probably be to clean this up on Geant4's side