### PR TITLE
Fix compile error Cannot open include file: 'vtk3DSImporter.h'

### DIFF
--- a/cmake/Modules/G4InterfaceOptions.cmake
+++ b/cmake/Modules/G4InterfaceOptions.cmake
@@ -80,6 +80,7 @@ if(GEANT4_USE_VTK)
     CommonColor
     InteractionStyle
     IOExport
+    IOImport
     IOGeometry
     IOLegacy
     IOPLY


### PR DESCRIPTION
The full error message was:

`source\visualization\Vtk\src\G4VtkViewer.cc(43,10): error C1083: Cannot open include file: 'vtk3DSImporter.h': No such file or directory`