### PR TITLE
StatMF MacroCanonical fix

### DIFF
--- a/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFMacroCanonical.cc
+++ b/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFMacroCanonical.cc
@@ -167,7 +167,7 @@ G4double G4StatMFMacroCanonical::ChooseA(G4int A, std::vector<G4int>& ANumbers)
     G4int SumA = 0;
     G4int ThisOne = 0;
     multiplicity = 0.0;
-    ANumbers.resize(A, 0);
+    ANumbers.assign(A, 0);
     do {
       G4double RandNumber = G4UniformRand()*pMeanMultiplicity;
       for (G4int i = 0; i < A; ++i) {


### PR DESCRIPTION
In Geant4 v11.4.0 release the Macrocanonical part of Statistical Multifragmentation Model has been changed. In particular, in the function `G4StatMFMacroCanonical::ChooseA` that decides the masses of the resulting fragments, the procedure for invalidating the resulting mass distribution vector upon rejecting the sample was changed from explicit for-loop to `std::vector::resize`. This, however, is a mistake, since `resize` [does nothing](https://en.cppreference.com/cpp/container/vector/resize) if the vector's size is equal to the requested one.

Therefore, upon sample rejection, the mass distribution vector kept the distributions from previous samples and new sample was added to them. This results in the model working correctly only if the very first sample is valid, which is rare, even more so for heavier fragments. When testing to find this issue, I observed **millions** of fragments with A=1 produced from a single A=150 nucleus remnant going through de-excitation. The returned distribution breaks the following logic of `G4StatMFMacroCanonical::ChooseZ` and results in the stall of de-excitation model, but does not produce any errors (at least for about 5 minutes I was willing to wait before looking into it).

I propose to change the function from `std::vector::resize` to `std::vector::assign` that both resizes the vector (if needed) and always replaces its contents with the second argument (as intended by the logic of `ChooseA` function).