### PR TITLE
Filter for ions

### DIFF
--- a/source/digits_hits/scorer/include/G4SDParticleFilter.hh
+++ b/source/digits_hits/scorer/include/G4SDParticleFilter.hh
@@ -67,6 +67,7 @@ class G4SDParticleFilter : public G4VSDFilter
     void add(const G4String& particleName);
     // set method for acceptable particle name.
     //
+    void addIon(G4int Z, G4int A, G4double E, char flb);
     void addIon(G4int Z, G4int A);
     void show();
 

--- a/source/digits_hits/scorer/src/G4SDParticleFilter.cc
+++ b/source/digits_hits/scorer/src/G4SDParticleFilter.cc
@@ -28,9 +28,12 @@
 // G4VSensitiveDetector
 #include "G4SDParticleFilter.hh"
 
+#include "G4IonTable.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTable.hh"
 #include "G4Step.hh"
+
+#include <string>
 
 ////////////////////////////////////////////////////////////////////////////////
 // class description:
@@ -124,6 +127,24 @@ void G4SDParticleFilter::add(const G4String& particleName)
     if (i == pd) return;
   }
   thePdef.push_back(pd);
+}
+
+void G4SDParticleFilter::addIon(G4int Z, G4int A, G4double E, char flb)
+{
+  G4ParticleDefinition* ion = G4IonTable::GetIonTable()->GetIon(Z, A, E, flb);
+  if (ion == nullptr)
+  {
+    G4String msg = "Ion <";
+    msg += "Z=" + std::to_string(Z) + ", A=" + std::to_string(A);
+    msg += ", E=" + std::to_string(E) + ", flb=" + flb;
+    msg += "> not found.";
+    G4Exception("G4SDParticleFilter::addIon()", "DetPS0104", FatalException, msg);
+  }
+  for (auto& i : thePdef)
+  {
+    if (i == ion) return;
+  }
+  thePdef.push_back(ion);
 }
 
 void G4SDParticleFilter::addIon(G4int Z, G4int A)

--- a/source/digits_hits/utils/include/G4ScoreQuantityMessenger.hh
+++ b/source/digits_hits/utils/include/G4ScoreQuantityMessenger.hh
@@ -66,6 +66,8 @@ class G4ScoreQuantityMessenger : public G4UImessenger
     void FillTokenVec(const G4String& newValues, G4TokenVec& token);
 
     void FParticleCommand(G4VScoringMesh* mesh, G4TokenVec& token);
+    G4bool FIonCommand(G4VScoringMesh* mesh, const G4String& newValues);
+    G4bool FIonsCommand(G4VScoringMesh* mesh, G4TokenVec& token);
     void FParticleWithEnergyCommand(G4VScoringMesh* mesh, G4TokenVec& token);
 
     G4bool CheckMeshPS(G4VScoringMesh* mesh, const G4String& psname, G4UIcommand* command);
@@ -113,6 +115,8 @@ class G4ScoreQuantityMessenger : public G4UImessenger
     G4UIcmdWithAString* fneutralCmd;
     G4UIcommand* fkinECmd;
     G4UIcommand* fparticleCmd;
+    G4UIcommand* fionCmd;
+    G4UIcommand* fionsCmd;
     G4UIcommand* fparticleKinECmd;
     //
 };

--- a/source/digits_hits/utils/src/G4ScoreQuantityMessenger.cc
+++ b/source/digits_hits/utils/src/G4ScoreQuantityMessenger.cc
@@ -458,6 +458,39 @@ void G4ScoreQuantityMessenger::FilterCommands()
   param->SetDefaultValue("");
   fparticleCmd->SetParameter(param);
   //
+  fionCmd = new G4UIcommand("/score/filter/ion", this);
+  fionCmd->SetGuidance("Ion filter using Z A [E flb]");
+  fionCmd->SetGuidance("[usage] /score/filter/ion fname Z A [E flb]");
+  fionCmd->SetGuidance("  fname     :(String) Filter Name ");
+  fionCmd->SetGuidance("  Z         :(int) AtomicNumber");
+  fionCmd->SetGuidance("  A         :(int) AtomicMass");
+  fionCmd->SetGuidance("  E         :(double) Excitation energy (in keV)");
+  fionCmd->SetGuidance("  flb       :(String) Floating level base");
+  param = new G4UIparameter("fname", 's', false);
+  fionCmd->SetParameter(param);
+  param = new G4UIparameter("Z", 'i', false);
+  fionCmd->SetParameter(param);
+  param = new G4UIparameter("A", 'i', false);
+  fionCmd->SetParameter(param);
+  param = new G4UIparameter("E", 'd', true);
+  param->SetDefaultValue(0.0);
+  fionCmd->SetParameter(param);
+  param = new G4UIparameter("flb", 's', true);
+  param->SetDefaultValue("noFloat");
+  param->SetParameterCandidates("noFloat X Y Z U V W R S T A B C D E");
+  fionCmd->SetParameter(param);
+  //
+  fionsCmd = new G4UIcommand("/score/filter/ions", this);
+  fionsCmd->SetGuidance("Ion filter using Z, A.");
+  fionsCmd->SetGuidance("[usage] /score/filter/ions fname Z0 A0 .. Zn An");
+  fionsCmd->SetGuidance("  fname           :(String) Filter Name ");
+  fionsCmd->SetGuidance("  Z0 A0 .. Zn AN  :(Int) Z and A of ions");
+  param = new G4UIparameter("fname", 's', false);
+  fionsCmd->SetParameter(param);
+  param = new G4UIparameter("ionlist", 's', false);
+  param->SetDefaultValue("");
+  fionsCmd->SetParameter(param);
+  //
   //
   //
   fparticleKinECmd = new G4UIcommand("/score/filter/particleWithKineticEnergy", this);
@@ -524,6 +557,8 @@ G4ScoreQuantityMessenger::~G4ScoreQuantityMessenger()
   delete fneutralCmd;
   delete fkinECmd;
   delete fparticleCmd;
+  delete fionCmd;
+  delete fionsCmd;
   delete fparticleKinECmd;
 }
 
@@ -1022,6 +1057,40 @@ void G4ScoreQuantityMessenger::SetNewValue(G4UIcommand* command, G4String newVal
       command->CommandFailed(ed);
     }
   }
+  else if (command == fionCmd)
+  {
+    if (!mesh->IsCurrentPrimitiveScorerNull())
+    {
+      if (!FIonCommand(mesh, newVal))
+      {
+        ed << "ERROR : Invalid definition of ion filter.";
+        command->CommandFailed(ed);
+      }
+    }
+    else
+    {
+      ed << "WARNING[" << fionCmd->GetCommandPath()
+         << "] : Current quantity is not set. Set or touch a quantity first.";
+      command->CommandFailed(ed);
+    }
+  }
+  else if (command == fionsCmd)
+  {
+    if (!mesh->IsCurrentPrimitiveScorerNull())
+    {
+      if (!FIonsCommand(mesh, token))
+      {
+        ed << "ERROR : Invalid definition of ion filter.";
+        command->CommandFailed(ed);
+      }
+    }
+    else
+    {
+      ed << "WARNING[" << fionsCmd->GetCommandPath()
+         << "] : Current quantity is not set. Set or touch a quantity first.";
+      command->CommandFailed(ed);
+    }
+  }
 }
 
 G4String G4ScoreQuantityMessenger::GetCurrentValue(G4UIcommand* /*command*/)
@@ -1056,6 +1125,61 @@ void G4ScoreQuantityMessenger::FParticleCommand(G4VScoringMesh* mesh, G4TokenVec
   //
   // Attach Filter
   mesh->SetFilter(new G4SDParticleFilter(name, pnames));
+}
+
+G4bool G4ScoreQuantityMessenger::FIonCommand(G4VScoringMesh* mesh, const G4String& newValues)
+{
+  // taken from G4ParticleGunMessenger::IonCommand
+  G4Tokenizer next(newValues);
+  G4String name = next();
+  G4int atomicNumber = StoI(next());
+  G4int atomicMass = StoI(next());
+  G4double ionExciteEnergy = 0.0;
+  char ionFloatingLevelBase = '\0';
+  G4String sQ = next();
+  if (!(sQ.empty()))
+  {
+    ionExciteEnergy = StoD(sQ) * CLHEP::keV;
+    sQ = next();
+    if (sQ.empty() || sQ == "noFloat")
+    {
+      ionFloatingLevelBase = '\0';
+    }
+    else
+    {
+      ionFloatingLevelBase = sQ[(std::size_t)0];
+    }
+  }
+
+  // Attach Filter
+  auto filter = new G4SDParticleFilter(name);
+  filter->addIon(atomicNumber, atomicMass, ionExciteEnergy, ionFloatingLevelBase);
+  mesh->SetFilter(filter);
+  return true;
+}
+
+G4bool G4ScoreQuantityMessenger::FIonsCommand(G4VScoringMesh* mesh, G4TokenVec& token)
+{
+  //
+  // Filter name
+  G4String name = token[0];
+  //
+  // ion list
+  std::vector<G4int> ionAZ;
+  for (G4int i = 1; i < (G4int)token.size(); i++)
+  {
+    ionAZ.push_back(StoI(token[i]));
+  }
+  //
+  // Check A,Z pairs
+  if (ionAZ.size() % 2) return false;
+
+  // Attach Filter
+  auto filter = new G4SDParticleFilter(name);
+  for (G4int i = 0; i < (G4int)ionAZ.size(); i = i + 2)
+    filter->addIon(ionAZ[i], ionAZ[i + 1]);
+  mesh->SetFilter(filter);
+  return true;
 }
 
 void G4ScoreQuantityMessenger::FParticleWithEnergyCommand(G4VScoringMesh* mesh, G4TokenVec& token)


### PR DESCRIPTION
This adds the commands ``/score/filter/ion`` and ``/score/filter/ions`` in order to enable filtering of ions. This can be used to, e.g., score activation products.

Filtering based on A, Z was already implemented in ``G4SDParticleFilter`` but no command has been defined in ``G4ScoreQuantityMessenger``. Therefore I added ``/score/filter/ions`` where multiple A,Z pairs can be specified similarly to ``/score/filter/particle``. Unfortunately, this filters only on A and Z and does not check for excited states, which can lead to wrong counting. That's why I also implemented ``/score/filter/ion``.

``/score/filter/ion`` enables the selection of specific ion states similarly to ``/gun/ion`` and enables thus to, e.g., select the ground states only.

The code has been already formatted by clan-format.