### PR TITLE
g4tools: only take the HDF5 1.6 code path on HDF5 1.x

### DIFF
--- a/source/externals/g4tools/include/toolx/hdf5/hdf5_h
+++ b/source/externals/g4tools/include/toolx/hdf5/hdf5_h
@@ -6,7 +6,7 @@
 
 #include <hdf5.h>
 
-#if (H5_VERS_MAJOR >= 1) && (H5_VERS_MINOR <= 6)
+#if (H5_VERS_MAJOR == 1) && (H5_VERS_MINOR <= 6)
 #  define toolx_H5Dopen H5Dopen
 #  define toolx_H5Dcreate H5Dcreate
 #  define toolx_H5Acreate H5Acreate


### PR DESCRIPTION
I ran into this failure when trying to build Geant4 against HDF5 2.0