### PR TITLE
fix: correct anti_nu_nu to anti_nu_mu in G4NeutrinoElectronNcModel.cc

### DIFF
--- a/source/processes/hadronic/models/coherent_elastic/src/G4NeutrinoElectronNcModel.cc
+++ b/source/processes/hadronic/models/coherent_elastic/src/G4NeutrinoElectronNcModel.cc
@@ -82,7 +82,7 @@ G4bool G4NeutrinoElectronNcModel::IsApplicable(const G4HadProjectile& aTrack, G4
   {
     minEnergy = 0.5 * (fCutEnergy + sqrt(fCutEnergy * (fCutEnergy + 2. * electron_mass_c2)));
   }
-  if ((pName == "nu_e" || pName == "anti_nu_e" || pName == "nu_mu" || pName == "anti_nu_nu"
+  if ((pName == "nu_e" || pName == "anti_nu_e" || pName == "nu_mu" || pName == "anti_nu_mu"
        || pName == "nu_tau" || pName == "anti_nu_tau")
       && energy > minEnergy)
   {


### PR DESCRIPTION
## Summary
Corrects a particle name typo in `G4NeutrinoElectronNcModel::IsApplicable()`. The muon anti-neutrino was incorrectly named `anti_nu_nu` instead of `anti_nu_mu`, preventing proper neutral current electron scattering for muon anti-neutrinos.

## Fix
- File: `source/processes/hadronic/models/coherent_elastic/src/G4NeutrinoElectronNcModel.cc`
- Change: `anti_nu_nu` → `anti_nu_mu` in the particle name check

## Verification
Fixes issue #1 reported by headunderheels/geant4.

---
*Submitted via Jah-yee/geant4 PR branch fix/anti-nu-mu-typo*