### PR TITLE
Fix neutrino name typo in G4NeutrinoElectronNcModel.cc

### DIFF
--- a/source/processes/hadronic/models/coherent_elastic/src/G4NeutrinoElectronNcModel.cc
+++ b/source/processes/hadronic/models/coherent_elastic/src/G4NeutrinoElectronNcModel.cc
@@ -82,7 +82,7 @@ G4bool G4NeutrinoElectronNcModel::IsApplicable(const G4HadProjectile& aTrack, G4
   {
     minEnergy = 0.5 * (fCutEnergy + sqrt(fCutEnergy * (fCutEnergy + 2. * electron_mass_c2)));
   }
-  if ((pName == "nu_e" || pName == "anti_nu_e" || pName == "nu_mu" || pName == "anti_nu_nu"
+  if ((pName == "nu_e" || pName == "anti_nu_e" || pName == "nu_mu" || pName == "anti_nu_mu"
        || pName == "nu_tau" || pName == "anti_nu_tau")
       && energy > minEnergy)
   {


### PR DESCRIPTION
In `G4NeutrinoElectronNcModel.cc`, in `IsApplicable()` there was a typo on line 85 in the name of the “anti_nu_mu” particle that instead named it as “anti_nu_nu”. I have fixed this typo here.