### PR TITLE
Fix IMD formula in G4NeutrinoElectronCcXsc.cc & G4NeutrinoElectronCcModel.cc

### DIFF
--- a/source/processes/hadronic/cross_sections/src/G4NeutrinoElectronCcXsc.cc
+++ b/source/processes/hadronic/cross_sections/src/G4NeutrinoElectronCcXsc.cc
@@ -83,7 +83,7 @@ G4bool G4NeutrinoElectronCcXsc::IsElementApplicable(const G4DynamicParticle* aPa
   else
     fmass = emass;
 
-  minEnergy = (fmass - emass) * (fmass + emass) / emass;
+  minEnergy = (fmass - emass) * (fmass + emass) / (2 * emass);
 
   if ((pName == "nu_mu" || pName == "anti_nu_mu" || pName == "nu_tau" || pName == "anti_nu_tau")
       && energy > minEnergy)

--- a/source/processes/hadronic/models/lepto_nuclear/src/G4NeutrinoElectronCcModel.cc
+++ b/source/processes/hadronic/models/lepto_nuclear/src/G4NeutrinoElectronCcModel.cc
@@ -106,7 +106,7 @@ G4bool G4NeutrinoElectronCcModel::IsApplicable(const G4HadProjectile& aPart, G4N
   else
     fmass = emass;
 
-  minEnergy = (fmass - emass) * (fmass + emass) / emass;
+  minEnergy = (fmass - emass) * (fmass + emass) / (2 * emass);
   SetMinEnergy(minEnergy);
 
   if ((pName == "nu_mu" || pName == "nu_tau" || pName == "anti_nu_e") && energy > minEnergy)
@@ -138,7 +138,7 @@ G4HadFinalState* G4NeutrinoElectronCcModel::ApplyYourself(const G4HadProjectile&
   else
     fmass = emass;
 
-  minEnergy = (fmass - emass) * (fmass + emass) / emass;
+  minEnergy = (fmass - emass) * (fmass + emass) / (2 * emass);
 
   if (energy <= minEnergy)
   {


### PR DESCRIPTION
Inverse Muon (& Tau) Decay (IMD) has a threshold energy defined by  $$E_{thresh} \geq \frac{m_\mu^2-m_e^2}{2m_e} = (m_\mu-m_e)(m_\mu+m_e)/(2m_e) $$
This formula is missing a factor of 2 in the implementation in `G4NeutrinoElectronCcXsc.cc` and `G4NeutrinoElectronCcModel.cc`, which causes IMD not to happen until ~22 GeV rather than ~11 GeV as is proper. Those typos have been remedied here.