### PR TITLE
ascii: Support for G4CutTubs

### DIFF
--- a/source/persistency/ascii/src/G4tgbGeometryDumper.cc
+++ b/source/persistency/ascii/src/G4tgbGeometryDumper.cc
@@ -33,6 +33,7 @@
 #include "G4BooleanSolid.hh"
 #include "G4Box.hh"
 #include "G4Cons.hh"
+#include "G4CutTubs.hh"
 #include "G4Element.hh"
 #include "G4Ellipsoid.hh"
 #include "G4EllipticalCone.hh"
@@ -803,6 +804,26 @@ std::vector<G4double> G4tgbGeometryDumper::GetSolidParams(const G4VSolid* so)
       params.push_back(tu->GetZHalfLength());
       params.push_back(tu->GetStartPhiAngle() / deg);
       params.push_back(tu->GetDeltaPhiAngle() / deg);
+    }
+  }
+  else if (solidType == "CUTTUBS")
+  {
+    const G4CutTubs* ctu = dynamic_cast<const G4CutTubs*>(so);
+    if (ctu != nullptr)
+    {
+      G4ThreeVector lowNorm(ctu->GetLowNorm());
+      G4ThreeVector highNorm(ctu->GetHighNorm());
+      params.push_back(ctu->GetInnerRadius());
+      params.push_back(ctu->GetOuterRadius());
+      params.push_back(ctu->GetZHalfLength());
+      params.push_back(ctu->GetStartPhiAngle() / deg);
+      params.push_back(ctu->GetDeltaPhiAngle() / deg);
+      params.push_back(lowNorm.x());
+      params.push_back(lowNorm.y());
+      params.push_back(lowNorm.z());
+      params.push_back(highNorm.x());
+      params.push_back(highNorm.y());
+      params.push_back(highNorm.z());
     }
   }
   else if (solidType == "TRAP")

--- a/source/persistency/ascii/src/G4tgbVolume.cc
+++ b/source/persistency/ascii/src/G4tgbVolume.cc
@@ -33,6 +33,7 @@
 #include "G4AssemblyVolume.hh"
 #include "G4Box.hh"
 #include "G4Cons.hh"
+#include "G4CutTubs.hh"
 #include "G4Ellipsoid.hh"
 #include "G4EllipticalCone.hh"
 #include "G4EllipticalTube.hh"
@@ -253,6 +254,20 @@ G4VSolid* G4tgbVolume::FindOrConstructG4Solid(const G4tgrSolid* sol)
       phiDelta = twopi;
     }
     solid = new G4Tubs(sname, solParam[0], solParam[1], solParam[2], solParam[3], phiDelta);
+  }
+  else if (stype == "CUTTUBS")
+  {
+    CheckNoSolidParams(stype, 11, (G4int)solParam.size());
+    G4double phiDelta = solParam[4];
+    if (std::fabs(phiDelta - twopi) < angularTolerance)
+    {
+      phiDelta = twopi;
+    }
+    G4ThreeVector lowNorm(solParam[5], solParam[6], solParam[7]);
+    G4ThreeVector highNorm(solParam[8], solParam[9], solParam[10]);
+    solid = new G4CutTubs(sname, solParam[0], solParam[1], solParam[2],  // rmin, rmax, dz
+                          solParam[3], solParam[4],  // sphi, dphi
+                          lowNorm, highNorm);
   }
   else if (stype == "TRAP")
   {

--- a/source/persistency/ascii/src/G4tgrSolid.cc
+++ b/source/persistency/ascii/src/G4tgrSolid.cc
@@ -95,6 +95,10 @@ void G4tgrSolid::FillSolidParams(const std::vector<G4String>& wl)
   apar.insert(4);
   angleParams["TUBS"] = apar;
   apar.clear();
+  apar.insert(3);
+  apar.insert(4);
+  angleParams["CUTTUBS"] = apar;
+  apar.clear();
   apar.insert(5);
   apar.insert(6);
   angleParams["CONS"] = apar;


### PR DESCRIPTION
Support for the CSG solid G4CutTubs has been added to textgeom (ASCII persistency).

Parameters:
pRMin pRMax pDz pSPhi pDPhi pLowNorm-x pLowNorm-y pLowNorm-z pHighNorm-x pHighNorm-y pHighNorm-z

Example usage (generates the G4CutTubs example from the Geant4 Book For Application Developers):

`:SOLID aSolid CUTTUBS 12*cm 20*cm 30*cm 0 3/2*180*deg 0 -0.7 -0.71 0.7 0 0.71`

clang-format has been applied.